### PR TITLE
add: 集約とコマンド、イベントを表す構造体・列挙体を追加する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,8 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "lib",
+ "thiserror",
  "ulid",
 ]
 
@@ -144,6 +146,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,18 @@ name = "app"
 version = "0.1.0"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "driver"
 version = "0.1.0"
 
@@ -19,9 +31,204 @@ name = "example-cqrs-event-store"
 version = "0.1.0"
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "ulid",
+]
 
 [[package]]
 name = "lib"
 version = "0.1.0"
+
+[[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ulid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
+dependencies = [
+ "getrandom",
+ "rand",
+ "web-time",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "web-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]

--- a/internal/kernel/Cargo.toml
+++ b/internal/kernel/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+lib = { version = "0.1.0", path = "../lib" }
+thiserror = "1.0.56"
 ulid = "1.1.2"

--- a/internal/kernel/Cargo.toml
+++ b/internal/kernel/Cargo.toml
@@ -3,6 +3,5 @@ name = "kernel"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+ulid = "1.1.2"

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,3 +1,7 @@
+use lib::Result;
+
+use crate::command::WidgetCommand;
+use crate::error::AggregateError;
 use crate::event::WidgetEvent;
 use crate::Id;
 
@@ -29,6 +33,23 @@ impl WidgetAggregate {
     /// 集約のバージョン (= 更新回数)
     pub fn version(&self) -> u64 {
         self.version
+    }
+
+    /// 集約にコマンドを実行する
+    pub fn apply_command(self, command: WidgetCommand) -> Result<WidgetCommandState> {
+        let events = match command {
+            WidgetCommand::CreateWidget(event) => vec![event],
+            WidgetCommand::ChangeWidgetName(event) => vec![event],
+            WidgetCommand::ChangeWidgetDescription(event) => vec![event],
+        };
+        Ok(WidgetCommandState {
+            widget_id: self.id,
+            events,
+            aggregate_version: self
+                .version
+                .checked_add(1)
+                .ok_or(AggregateError::VersionUpdateLimitReached)?,
+        })
     }
 }
 

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,3 +1,4 @@
+use crate::event::WidgetEvent;
 use crate::Id;
 
 /// 部品 (Widget) の集約
@@ -28,5 +29,30 @@ impl WidgetAggregate {
     /// 集約のバージョン (= 更新回数)
     pub fn version(&self) -> u64 {
         self.version
+    }
+}
+
+/// 集約 (Aggregate) に対するコマンドの処理を成功して保存可能になった状態
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WidgetCommandState {
+    widget_id: Id<WidgetAggregate>,
+    events: Vec<WidgetEvent>,
+    aggregate_version: u64,
+}
+
+impl WidgetCommandState {
+    /// 部品の id
+    pub fn widget_id(&self) -> &Id<WidgetAggregate> {
+        &self.widget_id
+    }
+
+    /// 部品に対するコマンド
+    pub fn events(&self) -> &[WidgetEvent] {
+        &self.events
+    }
+
+    /// 集約のバージョン
+    pub fn aggregate_version(&self) -> u64 {
+        self.aggregate_version
     }
 }

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,0 +1,32 @@
+use crate::Id;
+
+/// 部品 (Widget) の集約
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WidgetAggregate {
+    id: Id<WidgetAggregate>,
+    name: String,
+    description: String,
+    version: u64,
+}
+
+impl WidgetAggregate {
+    /// 部品の id
+    pub fn id(&self) -> &Id<WidgetAggregate> {
+        &self.id
+    }
+
+    /// 部品の名前
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// 部品の説明
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// 集約のバージョン (= 更新回数)
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+}

--- a/internal/kernel/src/command.rs
+++ b/internal/kernel/src/command.rs
@@ -1,0 +1,10 @@
+/// 部品 (Widget) に対するコマンド
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WidgetCommand {
+    /// 部品を新しく作成する
+    CreateWidget,
+    /// 部品の名前を変更する
+    ChangeWidgetName,
+    /// 部品の説明を変更する
+    ChangeWidgetDescription,
+}

--- a/internal/kernel/src/command.rs
+++ b/internal/kernel/src/command.rs
@@ -1,10 +1,12 @@
+use crate::event::WidgetEvent;
+
 /// 部品 (Widget) に対するコマンド
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum WidgetCommand {
     /// 部品を新しく作成する
-    CreateWidget,
+    CreateWidget(WidgetEvent),
     /// 部品の名前を変更する
-    ChangeWidgetName,
+    ChangeWidgetName(WidgetEvent),
     /// 部品の説明を変更する
-    ChangeWidgetDescription,
+    ChangeWidgetDescription(WidgetEvent),
 }

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AggregateError {
+    #[error("Cannot update Aggregate version")]
+    VersionUpdateLimitReached,
+}

--- a/internal/kernel/src/event.rs
+++ b/internal/kernel/src/event.rs
@@ -1,0 +1,29 @@
+use crate::Id;
+
+/// 部品 (Widget) に発生するイベント
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WidgetEvent {
+    /// 部品を新しく作成する
+    WidgetCreated {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        widget_name: String,
+        /// 部品の説明
+        widget_description: String,
+    },
+    /// 部品の名前を変更する
+    WidgetNameChanged {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        widget_name: String,
+    },
+    /// 部品の説明を変更する
+    WidgetDescriptionChanged {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        description: String,
+    },
+}

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -4,6 +4,7 @@ use ulid::Ulid;
 
 pub mod aggregate;
 pub mod command;
+pub mod event;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id<T> {

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use ulid::Ulid;
 
 pub mod aggregate;
+pub mod command;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id<T> {

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use ulid::Ulid;
 
+pub mod aggregate;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id<T> {
     value: Ulid,

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -4,6 +4,7 @@ use ulid::Ulid;
 
 pub mod aggregate;
 pub mod command;
+pub mod error;
 pub mod event;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -1,14 +1,9 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use std::marker::PhantomData;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+use ulid::Ulid;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Id<T> {
+    value: Ulid,
+    _maker: PhantomData<T>,
 }

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;


### PR DESCRIPTION
## Overview

Amazon Web Services ブログの [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) に出てくる集約 (Widget) やイベント、コマンドの構造体・列挙体を追加した。 
`internal/kernel` workspace 配下で定義したこれらは Service 層や Repository 層で利用することを想定している。
