### PR TITLE
add: 集約を永続化する処理のインターフェイスを追加する

### DIFF
--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -6,6 +6,7 @@ pub mod aggregate;
 pub mod command;
 pub mod error;
 pub mod event;
+pub mod processor;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id<T> {

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -1,0 +1,23 @@
+use lib::Result;
+
+use crate::aggregate::{WidgetAggregate, WidgetCommandState};
+use crate::Id;
+
+/// 集約を永続化する処理のインターフェイス
+pub trait CommandProcessor {
+    /// 部品の集約を新しく作成する
+    fn create_widget_aggregate(
+        &self,
+        command_state: WidgetCommandState,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    /// 部品の集約を取得する
+    fn get_widget_aggregate(
+        &self,
+        widget_id: Id<WidgetAggregate>,
+    ) -> impl std::future::Future<Output = Result<WidgetAggregate>> + Send;
+    /// 部品の集約を更新する
+    fn update_widget_aggregate(
+        &self,
+        command_state: WidgetCommandState,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+}


### PR DESCRIPTION
## Overview

集約を永続化する処理のインターフェイスを追加
Service 層でインターフェイスを利用し Repository 層で実体を定義する
