### PR TITLE
feat: AWS のブログを参考にイベントソーシングを実現する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,18 @@ name = "app"
 version = "0.1.0"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "driver"
 version = "0.1.0"
 
@@ -19,9 +31,226 @@ name = "example-cqrs-event-store"
 version = "0.1.0"
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "lib",
+ "thiserror",
+ "ulid",
+]
 
 [[package]]
 name = "lib"
 version = "0.1.0"
+
+[[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ulid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
+dependencies = [
+ "getrandom",
+ "rand",
+ "web-time",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "web-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -380,6 +380,7 @@ dependencies = [
  "driver",
  "kernel",
  "lib",
+ "sqlx",
  "tokio",
 ]
 
@@ -701,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1593,18 +1594,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,48 @@ version = 3
 [[package]]
 name = "adapter"
 version = "0.1.0"
+dependencies = [
+ "kernel",
+ "lib",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum_macros",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "app"
@@ -15,10 +57,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-write-file"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+dependencies = [
+ "nix",
+ "rand",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -27,12 +166,252 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "driver"
 version = "0.1.0"
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "example-cqrs-event-store"
 version = "0.1.0"
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -46,6 +425,108 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -66,6 +547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
+
+[[package]]
 name = "lib"
 version = "0.1.0"
 
@@ -76,16 +566,251 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -142,6 +867,433 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+dependencies = [
+ "atomic-write-file",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.4.2",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.4.2",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +1302,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -169,8 +1333,87 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ulid"
@@ -184,10 +1427,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -216,7 +1515,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -238,7 +1537,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -258,3 +1557,167 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ version = "0.1.0"
 dependencies = [
  "kernel",
  "lib",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,10 @@ version = "0.1.0"
 [[package]]
 name = "app"
 version = "0.1.0"
+dependencies = [
+ "kernel",
+ "lib",
+]
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +91,61 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -252,6 +318,15 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "driver"
 version = "0.1.0"
+dependencies = [
+ "app",
+ "axum",
+ "lib",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+]
 
 [[package]]
 name = "either"
@@ -298,6 +373,14 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "example-cqrs-event-store"
 version = "0.1.0"
+dependencies = [
+ "adapter",
+ "app",
+ "driver",
+ "kernel",
+ "lib",
+ "tokio",
+]
 
 [[package]]
 name = "fastrand"
@@ -321,6 +404,12 @@ dependencies = [
  "futures-sink",
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -433,6 +522,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "h2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +567,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -491,6 +605,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
 ]
 
 [[package]]
@@ -605,6 +800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +820,12 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -715,6 +922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +989,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -964,6 +1201,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1242,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1305,6 +1573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,9 +1635,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1376,6 +1664,65 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
+dependencies = [
+ "bitflags 2.4.2",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-cqrs-event-store"
 version = "0.1.0"
 edition = "2021"
+default-run = "example-cqrs-event-store"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,7 +12,15 @@ app = { version = "0.1.0", path = "internal/app" }
 driver = { version = "0.1.0", path = "internal/driver" }
 kernel = { version = "0.1.0", path = "internal/kernel" }
 lib = { version = "0.1.0", path = "internal/lib" }
+sqlx = { version = "0.7.3", features = ["runtime-tokio", "mysql"], optional = true }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [workspace]
 members = [ "internal/adapter", "internal/app","internal/driver", "internal/kernel", "internal/lib"]
+
+[features]
+migrate = ["sqlx"]
+
+[[bin]]
+name = "migrate"
+required-features = ["migrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+adapter = { version = "0.1.0", path = "internal/adapter" }
+app = { version = "0.1.0", path = "internal/app" }
+driver = { version = "0.1.0", path = "internal/driver" }
+kernel = { version = "0.1.0", path = "internal/kernel" }
+lib = { version = "0.1.0", path = "internal/lib" }
+tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [workspace]
 members = [ "internal/adapter", "internal/app","internal/driver", "internal/kernel", "internal/lib"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
 # Example of a CQRS event store
 
 このリポジトリは Amazon Web Services ブログの [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) を参考に Rust でイベントソーシングを試してみたリポジトリです。
+
+## Example
+
+### MySQL の DB を立ち上げてマイグレーションを実行する
+
+```bash
+docker compose up --wait
+cargo run --bin migrate --features migrate
+```
+
+MySQL の設定は環境変数によって変更することができます。
+
+| 環境変数名 | 説明 | デフォルト値 |
+|:-|:-|:-|
+| MYSQL_USERNAME | MySQL に接続するためのユーザー名 | `root` |
+| MYSQL_PASSWORD | MySQL に接続するためのパスワード | `root` |
+| MYSQL_PORT | ローカルにマッピングする MySQL のポート | `3306` |
+| MYSQL_DATABASE | MySQL のデータベース名 | `widget` |
+
+### サーバーを立ち上げる
+
+```bash
+cargo run --release
+```
+
+### MySQL クライアントで接続する
+
+```bash
+mysql -h 127.0.0.1 --user ${MYSQL_USERNAME:-root} -p${MYSQL_PASSWORD:-root} --port ${MYSQL_PORT:-3306} --database ${MYSQL_DATABASE:-widget}
+```
+
+### リクエスト
+
+Widget を作成する:
+
+```bash
+curl -s http://localhost:8080/widgets \
+  -H "Content-Type: application/json" \
+  -d '{ "widget_name": "widget name 1", "widget_description": "widget description 1"}'
+```
+
+Widget の名前を変更する:
+
+```bash
+curl -v "http://localhost:8080/widgets/${WIDGET_ID}/name" \
+  -H "Content-Type: application/json" \
+  -d '{ "widget_name": "widget name 2"}'
+```
+
+Widget の説明を変更する:
+
+```bash
+curl -v "http://localhost:8080/widgets/${WIDGET_ID}/description" \
+  -H "Content-Type: application/json" \
+  -d '{ "widget_description": "widget description 2"}'
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,14 @@
 services:
   database:
-    image: mysql:8.3
+    image: mysql:8.1
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT:-3306}:3306"
     environment:
-      MYSQL_ROOT_USER: "root"
-      MYSQL_ROOT_PASSWORD: "root"
-      MYSQL_DATABASE: "widget"
+      MYSQL_ROOT_USER: "${MYSQL_USERNAME:-root}"
+      MYSQL_ROOT_PASSWORD: "${MYSQL_PASSWORD:-root}"
+      MYSQL_DATABASE: "${MYSQL_DATABASE:-widget}"
     healthcheck:
       test: "mysqladmin ping --host 127.0.0.1 --user $$MYSQL_ROOT_USER -p$$MYSQL_ROOT_PASSWORD"
       interval: 10s
       timeout: 20s
       retries: 10
-

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  database:
+    image: mysql:8.3
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_USER: "root"
+      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_DATABASE: "widget"
+    healthcheck:
+      test: "mysqladmin ping --host 127.0.0.1 --user $$MYSQL_ROOT_USER -p$$MYSQL_ROOT_PASSWORD"
+      interval: 10s
+      timeout: 20s
+      retries: 10
+

--- a/internal/adapter/Cargo.toml
+++ b/internal/adapter/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+kernel = { version = "0.1.0", path = "../kernel" }
+lib = { version = "0.1.0", path = "../lib" }
+serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.113"
+sqlx = { version = "0.7.3", features = ["runtime-tokio", "mysql", "json"] }
+strum_macros = "0.26.1"

--- a/internal/adapter/src/lib.rs
+++ b/internal/adapter/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub(crate) mod model;
+pub mod persistence;
+pub mod repository;

--- a/internal/adapter/src/model.rs
+++ b/internal/adapter/src/model.rs
@@ -1,0 +1,235 @@
+use kernel::aggregate::WidgetCommandState;
+use kernel::event::WidgetEvent;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Aggregate テーブルのモデル
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WidgetAggregateModel {
+    widget_id: String,
+    last_events: serde_json::Value,
+    aggregate_version: u64,
+}
+
+impl WidgetAggregateModel {
+    pub(crate) fn widget_id(&self) -> &str {
+        &self.widget_id
+    }
+
+    pub(crate) fn last_events(&self) -> &serde_json::Value {
+        &self.last_events
+    }
+
+    pub(crate) fn aggregate_version(&self) -> u64 {
+        self.aggregate_version
+    }
+}
+
+impl TryFrom<WidgetCommandState> for WidgetAggregateModel {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn try_from(value: WidgetCommandState) -> Result<Self, Self::Error> {
+        Ok(Self {
+            widget_id: value.widget_id().to_string(),
+            last_events: serde_json::to_value(
+                value
+                    .events()
+                    .iter()
+                    .map(|x| x.clone().into())
+                    .collect::<Vec<WidgetEventMapper>>(),
+            )?,
+            aggregate_version: value.aggregate_version(),
+        })
+    }
+}
+
+/// Event テーブルのモデル
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WidgetEventModel {
+    event_id: String,
+    event_name: String,
+    payload: serde_json::Value,
+}
+
+impl WidgetEventModel {
+    pub(crate) fn event_id(&self) -> &str {
+        &self.event_id
+    }
+
+    pub(crate) fn event_name(&self) -> &str {
+        &self.event_name
+    }
+
+    pub(crate) fn payload(&self) -> &serde_json::Value {
+        &self.payload
+    }
+}
+
+/// `WidgetEventModel` の配列を NewType パターンで表現する
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WidgetEventModels(pub(crate) Vec<WidgetEventModel>);
+
+/// `WidgetAggregateModel` の last_events から `WidgetEventModel` の配列に変換する
+impl TryFrom<WidgetAggregateModel> for WidgetEventModels {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn try_from(value: WidgetAggregateModel) -> Result<Self, Self::Error> {
+        let mappers: Vec<WidgetEventMapper> = serde_json::from_value(value.last_events)?;
+        let mut models = Vec::new();
+        for mapper in mappers {
+            let model = WidgetEventModel {
+                event_id: mapper.event_id().to_string(),
+                event_name: mapper.event_name(),
+                payload: mapper.to_payload_json_value()?,
+            };
+            models.push(model);
+        }
+        Ok(Self(models))
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(
+    Serialize, Deserialize, strum_macros::Display, Debug, Clone, PartialEq, Eq, PartialOrd, Ord,
+)]
+#[serde(tag = "event_name")]
+pub(crate) enum WidgetEventMapper {
+    WidgetCreated {
+        event_id: String,
+        payload: WidgetCreatedPayload,
+    },
+    WidgetNameChanged {
+        event_id: String,
+        payload: WidgetNameChangedPayload,
+    },
+    WidgetDescriptionChanged {
+        event_id: String,
+        payload: WidgetDescriptionChangedPayload,
+    },
+}
+
+impl WidgetEventMapper {
+    /// イベントの名前
+    fn event_name(&self) -> String {
+        self.to_string()
+    }
+
+    /// イベントの ID
+    fn event_id(&self) -> &str {
+        match &self {
+            WidgetEventMapper::WidgetCreated { event_id, .. } => event_id,
+            WidgetEventMapper::WidgetNameChanged { event_id, .. } => event_id,
+            WidgetEventMapper::WidgetDescriptionChanged { event_id, .. } => event_id,
+        }
+    }
+
+    fn to_payload_json_value(
+        &self,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let payload = match &self {
+            WidgetEventMapper::WidgetCreated { payload, .. } => serde_json::to_value(payload)?,
+            WidgetEventMapper::WidgetNameChanged { payload, .. } => serde_json::to_value(payload)?,
+            WidgetEventMapper::WidgetDescriptionChanged { payload, .. } => {
+                serde_json::to_value(payload)?
+            }
+        };
+        Ok(payload)
+    }
+}
+
+impl From<WidgetEvent> for WidgetEventMapper {
+    fn from(value: WidgetEvent) -> Self {
+        match value {
+            WidgetEvent::WidgetCreated {
+                id,
+                widget_name,
+                widget_description,
+            } => Self::WidgetCreated {
+                event_id: id.to_string(),
+                payload: WidgetCreatedPayload::V1 {
+                    widget_name,
+                    widget_description,
+                },
+            },
+            WidgetEvent::WidgetNameChanged { id, widget_name } => Self::WidgetNameChanged {
+                event_id: id.to_string(),
+                payload: WidgetNameChangedPayload::V1 { widget_name },
+            },
+            WidgetEvent::WidgetDescriptionChanged {
+                id,
+                widget_description,
+            } => Self::WidgetDescriptionChanged {
+                event_id: id.to_string(),
+                payload: WidgetDescriptionChangedPayload::V1 { widget_description },
+            },
+        }
+    }
+}
+
+impl TryFrom<WidgetEventModel> for WidgetEventMapper {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn try_from(value: WidgetEventModel) -> Result<Self, Self::Error> {
+        let value = serde_json::json!({
+            "event_id": value.event_id,
+            "event_name": value.event_name,
+            "payload": value.payload,
+        });
+        Ok(serde_json::from_value(value)?)
+    }
+}
+
+impl TryInto<WidgetEvent> for WidgetEventMapper {
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn try_into(self) -> Result<WidgetEvent, Self::Error> {
+        let event = match self {
+            WidgetEventMapper::WidgetCreated { event_id, payload } => match payload {
+                WidgetCreatedPayload::V1 {
+                    widget_name,
+                    widget_description,
+                } => WidgetEvent::WidgetCreated {
+                    id: event_id.parse()?,
+                    widget_name,
+                    widget_description,
+                },
+            },
+            WidgetEventMapper::WidgetNameChanged { event_id, payload } => match payload {
+                WidgetNameChangedPayload::V1 { widget_name } => WidgetEvent::WidgetNameChanged {
+                    id: event_id.parse()?,
+                    widget_name,
+                },
+            },
+            WidgetEventMapper::WidgetDescriptionChanged { event_id, payload } => match payload {
+                WidgetDescriptionChangedPayload::V1 { widget_description } => {
+                    WidgetEvent::WidgetDescriptionChanged {
+                        id: event_id.parse()?,
+                        widget_description,
+                    }
+                }
+            },
+        };
+        Ok(event)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "version")]
+pub(crate) enum WidgetCreatedPayload {
+    V1 {
+        widget_name: String,
+        widget_description: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "version")]
+pub(crate) enum WidgetNameChangedPayload {
+    V1 { widget_name: String },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "version")]
+pub(crate) enum WidgetDescriptionChangedPayload {
+    V1 { widget_description: String },
+}

--- a/internal/adapter/src/model.rs
+++ b/internal/adapter/src/model.rs
@@ -1,5 +1,6 @@
 use kernel::aggregate::WidgetCommandState;
 use kernel::event::WidgetEvent;
+use lib::Error;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
@@ -26,7 +27,7 @@ impl WidgetAggregateModel {
 }
 
 impl TryFrom<WidgetCommandState> for WidgetAggregateModel {
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Error = Error;
 
     fn try_from(value: WidgetCommandState) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -71,7 +72,7 @@ pub(crate) struct WidgetEventModels(pub(crate) Vec<WidgetEventModel>);
 
 /// `WidgetAggregateModel` の last_events から `WidgetEventModel` の配列に変換する
 impl TryFrom<WidgetAggregateModel> for WidgetEventModels {
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Error = Error;
 
     fn try_from(value: WidgetAggregateModel) -> Result<Self, Self::Error> {
         let mappers: Vec<WidgetEventMapper> = serde_json::from_value(value.last_events)?;
@@ -123,9 +124,7 @@ impl WidgetEventMapper {
         }
     }
 
-    fn to_payload_json_value(
-        &self,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn to_payload_json_value(&self) -> Result<serde_json::Value, Error> {
         let payload = match &self {
             WidgetEventMapper::WidgetCreated { payload, .. } => serde_json::to_value(payload)?,
             WidgetEventMapper::WidgetNameChanged { payload, .. } => serde_json::to_value(payload)?,
@@ -167,7 +166,7 @@ impl From<WidgetEvent> for WidgetEventMapper {
 }
 
 impl TryFrom<WidgetEventModel> for WidgetEventMapper {
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Error = Error;
 
     fn try_from(value: WidgetEventModel) -> Result<Self, Self::Error> {
         let value = serde_json::json!({
@@ -180,7 +179,7 @@ impl TryFrom<WidgetEventModel> for WidgetEventMapper {
 }
 
 impl TryInto<WidgetEvent> for WidgetEventMapper {
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Error = Error;
 
     fn try_into(self) -> Result<WidgetEvent, Self::Error> {
         let event = match self {

--- a/internal/adapter/src/persistence.rs
+++ b/internal/adapter/src/persistence.rs
@@ -1,0 +1,12 @@
+use lib::Result;
+use sqlx::mysql::MySqlPoolOptions;
+use sqlx::{MySql, Pool};
+
+pub type ConnectionPool = Pool<MySql>;
+
+pub async fn connect(url: &str) -> Result<ConnectionPool> {
+    Ok(MySqlPoolOptions::new()
+        .max_connections(20)
+        .connect(url)
+        .await?)
+}

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -1,0 +1,128 @@
+use kernel::aggregate::{WidgetAggregate, WidgetAggregateState};
+use kernel::error::AggregateError;
+use kernel::event::WidgetEvent;
+use kernel::processor::CommandProcessor;
+use lib::Result;
+
+use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel, WidgetEventModels};
+use crate::persistence::ConnectionPool;
+
+pub struct WidgetRepository {
+    pool: ConnectionPool,
+}
+
+impl CommandProcessor for WidgetRepository {
+    async fn create_widget_aggregate(
+        &self,
+        command_state: kernel::aggregate::WidgetCommandState,
+    ) -> Result<()> {
+        let model: WidgetAggregateModel = command_state.try_into()?;
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "INSERT INTO aggregate (widget_id, last_events, aggregate_version) VALUES (?, ?, ?)",
+        )
+        .bind(model.widget_id())
+        .bind(model.last_events())
+        .bind(model.aggregate_version())
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn get_widget_aggregate(
+        &self,
+        widget_id: kernel::Id<kernel::aggregate::WidgetAggregate>,
+    ) -> Result<Option<kernel::aggregate::WidgetAggregate>> {
+        // Aggregate テーブルから関連する集約項目を取得する
+        let model: WidgetAggregateModel =
+            match sqlx::query_as("SELECT * FROM aggregate WHERE widget_id = ?")
+                .bind(widget_id.to_string())
+                .fetch_one(&self.pool)
+                .await
+            {
+                Ok(x) => x,
+                Err(e) => match e {
+                    sqlx::Error::RowNotFound => return Ok(None),
+                    _ => return Err(Box::new(e)),
+                },
+            };
+        // ビジネスロジックの適用の前にイベントと集約のデータが正しい状態にあることを保証するために
+        // 前回集約が保存された際に作成されたイベントを Event テーブルに個々の項目として永続化する
+        let widget_id = model.widget_id().to_string();
+        let aggregate_version = model.aggregate_version();
+        let WidgetEventModels(models) = model.try_into()?;
+        let mut tx = self.pool.begin().await?;
+        for model in models {
+            let result = sqlx::query(
+                "INSERT INTO event (event_id, widget_id, event_name, payload) VALUES (?, ?, ?, ?)",
+            )
+            .bind(model.event_id())
+            .bind(&widget_id)
+            .bind(model.event_name())
+            .bind(model.payload())
+            .execute(&mut *tx)
+            .await;
+            if let Err(e) = result {
+                match e.as_database_error() {
+                    // NOTE: イベントが既に存在してもイベントは変更不可能なのでエラーを無視する
+                    Some(e) if e.is_unique_violation() => continue,
+                    _ => return Err(Box::new(e)),
+                }
+            }
+        }
+        tx.commit().await?;
+        // 関連するすべてのイベントを読み込んで集約の状態を復元する
+        let models: Vec<WidgetEventModel> =
+            // NOTE: 時系列にしたがってイベントから集約を復元するために event_id の昇順でソートする
+            sqlx::query_as("SELECT * FROM event WHERE widget_id = ? ORDER BY event_id ASC")
+                .bind(widget_id)
+                .fetch_all(&self.pool)
+                .await?;
+        let mappers: Vec<Result<WidgetEventMapper>> =
+            models.into_iter().map(|x| x.try_into()).collect();
+        if mappers.iter().any(|x| x.is_err()) {
+            return Err("Parse mapper from model".into());
+        }
+        let events: Vec<Result<WidgetEvent>> =
+            mappers.into_iter().map(|x| x.unwrap().try_into()).collect();
+        if events.iter().any(|x| x.is_err()) {
+            return Err("Parse event from mapper".into());
+        }
+        let events: Vec<_> = events.into_iter().map(|x| x.unwrap()).collect();
+        Ok(Some(
+            WidgetAggregateState::new(WidgetAggregate::default(), events, aggregate_version)
+                .restore()?,
+        ))
+    }
+
+    async fn update_widget_aggregate(
+        &self,
+        command_state: kernel::aggregate::WidgetCommandState,
+    ) -> Result<()> {
+        let model: WidgetAggregateModel = command_state.try_into()?;
+        let mut tx = self.pool.begin().await?;
+        let result = sqlx::query(
+            "
+            UPDATE
+                aggregate
+            SET
+                last_events = ?, aggregate_version = ?
+            WHERE
+                widget_id = ? AND aggregate_version = ?
+            ",
+        )
+        .bind(model.last_events())
+        .bind(model.aggregate_version())
+        .bind(model.widget_id())
+        .bind(model.aggregate_version().saturating_sub(1))
+        .execute(&mut *tx)
+        .await?;
+        // NOTE: 同時接続で既に Aggregate が更新されていた場合はエラーを返す
+        if result.rows_affected() == 0 {
+            return Err(Box::new(AggregateError::Conflict));
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -11,6 +11,12 @@ pub struct WidgetRepository {
     pool: ConnectionPool,
 }
 
+impl WidgetRepository {
+    pub fn new(pool: ConnectionPool) -> Self {
+        Self { pool }
+    }
+}
+
 impl CommandProcessor for WidgetRepository {
     async fn create_widget_aggregate(
         &self,

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 kernel = { version = "0.1.0", path = "../kernel" }
 lib = { version = "0.1.0", path = "../lib" }
+thiserror = "1.0.56"

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+kernel = { version = "0.1.0", path = "../kernel" }
+lib = { version = "0.1.0", path = "../lib" }

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -1,14 +1,66 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use std::future::Future;
+
+use kernel::aggregate::WidgetAggregate;
+use kernel::command::WidgetCommand;
+use kernel::processor::CommandProcessor;
+use lib::Result;
+
+/// 部品 (Widget) のユースケース処理のインターフェイス
+pub trait WidgetService {
+    /// 部品を新しく作成する
+    fn create_widget(
+        &self,
+        widget_name: String,
+        widget_description: String,
+    ) -> impl Future<Output = Result<()>> + Send;
+    /// 部品の名前を変更する
+    fn change_widget_name(
+        &self,
+        widget_id: String,
+        widget_name: String,
+    ) -> impl Future<Output = Result<()>> + Send;
+    /// 部品の説明を変更する
+    fn change_widget_description(
+        &self,
+        widget_id: String,
+        widget_description: String,
+    ) -> impl Future<Output = Result<()>> + Send;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WidgetServiceImpl<C: CommandProcessor> {
+    command: C,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServiceImpl<C> {
+    async fn create_widget(&self, widget_name: String, widget_description: String) -> Result<()> {
+        let aggregate = WidgetAggregate::default();
+        let command = WidgetCommand::create_widget(widget_name, widget_description);
+        let command_state = aggregate.apply_command(command)?;
+        self.command.create_widget_aggregate(command_state).await
+    }
+
+    async fn change_widget_name(&self, widget_id: String, widget_name: String) -> Result<()> {
+        let aggregate = self
+            .command
+            .get_widget_aggregate(widget_id.parse()?)
+            .await?;
+        let command = WidgetCommand::change_widget_name(widget_name);
+        let command_state = aggregate.apply_command(command)?;
+        self.command.update_widget_aggregate(command_state).await
+    }
+
+    async fn change_widget_description(
+        &self,
+        widget_id: String,
+        widget_description: String,
+    ) -> Result<()> {
+        let aggregate = self
+            .command
+            .get_widget_aggregate(widget_id.parse()?)
+            .await?;
+        let command = WidgetCommand::change_widget_description(widget_description);
+        let command_state = aggregate.apply_command(command)?;
+        self.command.update_widget_aggregate(command_state).await
     }
 }

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -2,8 +2,23 @@ use std::future::Future;
 
 use kernel::aggregate::WidgetAggregate;
 use kernel::command::WidgetCommand;
+use kernel::error::{AggregateError, CommandError};
 use kernel::processor::CommandProcessor;
-use lib::Result;
+use lib::{Error, Result};
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WidgetServiceError {
+    /// Aggregate が存在しないときのエラー
+    #[error("Aggregate not found")]
+    AggregateNotFound,
+    /// Aggregate が既に更新さているときのエラー
+    #[error("Aggregate is already updated")]
+    AggregateConfilict,
+    /// 要求された値が不正なときのエラー
+    #[error("Invalid value")]
+    InvalidValue,
+}
 
 /// 部品 (Widget) のユースケース処理のインターフェイス
 pub trait WidgetService {
@@ -36,6 +51,25 @@ impl<C: CommandProcessor> WidgetServiceImpl<C> {
     pub fn new(command: C) -> Self {
         Self { command }
     }
+
+    fn handling_command_error(&self, err: Error) -> Error {
+        match err.downcast_ref::<CommandError>() {
+            Some(e) => match e {
+                CommandError::VersionUpdateLimitReached | CommandError::InvalidEvent => err,
+                CommandError::InvalidWidgetName | CommandError::InvalidWidgetDescription => {
+                    Box::new(WidgetServiceError::InvalidValue)
+                }
+            },
+            None => err,
+        }
+    }
+
+    fn handling_aggregate_error(&self, err: Error) -> Result<()> {
+        match err.downcast_ref::<AggregateError>() {
+            Some(AggregateError::Conflict) => Ok(()),
+            _ => Err(err),
+        }
+    }
 }
 
 impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServiceImpl<C> {
@@ -47,20 +81,37 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         let aggregate = WidgetAggregate::default();
         let widget_id = aggregate.id().to_string();
         let command = WidgetCommand::create_widget(widget_name, widget_description);
-        let command_state = aggregate.apply_command(command)?;
+        let command_state = aggregate
+            .apply_command(command)
+            .map_err(|e| self.handling_command_error(e))?;
         self.command.create_widget_aggregate(command_state).await?;
         Ok(widget_id)
     }
 
     async fn change_widget_name(&self, widget_id: String, widget_name: String) -> Result<()> {
-        let aggregate = self
-            .command
-            .get_widget_aggregate(widget_id.parse()?)
-            .await?
-            .ok_or("Aggregate not found")?;
-        let command = WidgetCommand::change_widget_name(widget_name);
-        let command_state = aggregate.apply_command(command)?;
-        self.command.update_widget_aggregate(command_state).await
+        const MAX_RETRY_COUNT: u32 = 3;
+        let mut retry_count = 0;
+        loop {
+            if retry_count > MAX_RETRY_COUNT {
+                return Err(Box::new(WidgetServiceError::AggregateConfilict));
+            }
+            let aggregate = self
+                .command
+                .get_widget_aggregate(widget_id.parse()?)
+                .await?
+                .ok_or(WidgetServiceError::AggregateNotFound)?;
+            let command = WidgetCommand::change_widget_name(widget_name.clone());
+            let command_state = aggregate
+                .apply_command(command)
+                .map_err(|e| self.handling_command_error(e))?;
+            let result = self.command.update_widget_aggregate(command_state).await;
+            if result.is_ok() {
+                break;
+            }
+            self.handling_aggregate_error(result.err().unwrap())?;
+            retry_count += 1;
+        }
+        Ok(())
     }
 
     async fn change_widget_description(
@@ -68,13 +119,28 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         widget_id: String,
         widget_description: String,
     ) -> Result<()> {
-        let aggregate = self
-            .command
-            .get_widget_aggregate(widget_id.parse()?)
-            .await?
-            .ok_or("Aggregate not found")?;
-        let command = WidgetCommand::change_widget_description(widget_description);
-        let command_state = aggregate.apply_command(command)?;
-        self.command.update_widget_aggregate(command_state).await
+        const MAX_RETRY_COUNT: u32 = 3;
+        let mut retry_count = 0;
+        loop {
+            if retry_count > MAX_RETRY_COUNT {
+                return Err(Box::new(WidgetServiceError::AggregateConfilict));
+            }
+            let aggregate = self
+                .command
+                .get_widget_aggregate(widget_id.parse()?)
+                .await?
+                .ok_or(WidgetServiceError::AggregateNotFound)?;
+            let command = WidgetCommand::change_widget_description(widget_description.clone());
+            let command_state = aggregate
+                .apply_command(command)
+                .map_err(|e| self.handling_command_error(e))?;
+            let result = self.command.update_widget_aggregate(command_state).await;
+            if result.is_ok() {
+                break;
+            }
+            self.handling_aggregate_error(result.err().unwrap())?;
+            retry_count += 1;
+        }
+        Ok(())
     }
 }

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -44,7 +44,8 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         let aggregate = self
             .command
             .get_widget_aggregate(widget_id.parse()?)
-            .await?;
+            .await?
+            .ok_or("Aggregate not found")?;
         let command = WidgetCommand::change_widget_name(widget_name);
         let command_state = aggregate.apply_command(command)?;
         self.command.update_widget_aggregate(command_state).await
@@ -58,7 +59,8 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         let aggregate = self
             .command
             .get_widget_aggregate(widget_id.parse()?)
-            .await?;
+            .await?
+            .ok_or("Aggregate not found")?;
         let command = WidgetCommand::change_widget_description(widget_description);
         let command_state = aggregate.apply_command(command)?;
         self.command.update_widget_aggregate(command_state).await

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -56,7 +56,7 @@ impl<C: CommandProcessor> WidgetServiceImpl<C> {
         match err.downcast_ref::<CommandError>() {
             Some(e) => match e {
                 CommandError::InvalidWidgetName | CommandError::InvalidWidgetDescription => {
-                    Box::new(WidgetServiceError::InvalidValue)
+                    WidgetServiceError::InvalidValue.into()
                 }
             },
             None => err,
@@ -92,7 +92,7 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         let mut retry_count = 0;
         loop {
             if retry_count > MAX_RETRY_COUNT {
-                return Err(Box::new(WidgetServiceError::AggregateConfilict));
+                return Err(WidgetServiceError::AggregateConfilict.into());
             }
             let aggregate = self
                 .command
@@ -122,7 +122,7 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         let mut retry_count = 0;
         loop {
             if retry_count > MAX_RETRY_COUNT {
-                return Err(Box::new(WidgetServiceError::AggregateConfilict));
+                return Err(WidgetServiceError::AggregateConfilict.into());
             }
             let aggregate = self
                 .command

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -55,7 +55,6 @@ impl<C: CommandProcessor> WidgetServiceImpl<C> {
     fn handling_command_error(&self, err: Error) -> Error {
         match err.downcast_ref::<CommandError>() {
             Some(e) => match e {
-                CommandError::VersionUpdateLimitReached | CommandError::InvalidEvent => err,
                 CommandError::InvalidWidgetName | CommandError::InvalidWidgetDescription => {
                     Box::new(WidgetServiceError::InvalidValue)
                 }

--- a/internal/driver/Cargo.toml
+++ b/internal/driver/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+app = { version = "0.1.0", path = "../app" }
+axum = "0.7.4"
+lib = { version = "0.1.0", path = "../lib" }
+serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.113"
+tokio = { version = "1.36.0", default-features = false, features = ["signal"] }
+tower-http = { version = "0.5.1", features = ["timeout"] }

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -1,14 +1,125 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use std::sync::Arc;
+use std::time::Duration;
+
+use app::WidgetService;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use lib::Error;
+use serde::Deserialize;
+use tokio::net::{TcpListener, ToSocketAddrs};
+use tokio::signal;
+use tower_http::timeout::TimeoutLayer;
+
+#[derive(Debug, Clone)]
+pub struct Server<T: ToSocketAddrs, S: WidgetService> {
+    addr: T,
+    service: Arc<S>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl<T: ToSocketAddrs + std::fmt::Display, S: WidgetService + Send + Sync + 'static> Server<T, S> {
+    pub fn new(addr: T, service: Arc<S>) -> Self {
+        Self { addr, service }
     }
+
+    pub async fn run(self) -> Result<(), Error> {
+        let router = Router::new()
+            .route("/healthz", get(|| async { StatusCode::OK }))
+            .nest(
+                "/widgets",
+                Router::new().route("/", post(create_widget)).nest(
+                    "/:widget_id",
+                    Router::new()
+                        .route("/name", post(change_widget_name))
+                        .route("/description", post(change_widget_description)),
+                ),
+            )
+            .with_state(self.service)
+            .layer(TimeoutLayer::new(Duration::from_millis(100)));
+        let listener = TcpListener::bind(&self.addr).await?;
+        println!("listening: {}", &self.addr);
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateWidget {
+    widget_name: String,
+    widget_description: String,
+}
+
+#[derive(Deserialize)]
+struct ChangeWidgetName {
+    widget_name: String,
+}
+
+#[derive(Deserialize)]
+struct ChangeWidgetDescription {
+    widget_description: String,
+}
+
+async fn create_widget<S: WidgetService>(
+    State(service): State<Arc<S>>,
+    Json(CreateWidget {
+        widget_name,
+        widget_description,
+    }): Json<CreateWidget>,
+) -> impl IntoResponse {
+    match service.create_widget(widget_name, widget_description).await {
+        Ok(id) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({ "widget_id": id })),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn change_widget_name<S: WidgetService>(
+    Path(widget_id): Path<String>,
+    State(service): State<Arc<S>>,
+    Json(ChangeWidgetName { widget_name }): Json<ChangeWidgetName>,
+) -> impl IntoResponse {
+    match service.change_widget_name(widget_id, widget_name).await {
+        Ok(_) => StatusCode::ACCEPTED.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn change_widget_description<S: WidgetService>(
+    Path(widget_id): Path<String>,
+    State(service): State<Arc<S>>,
+    Json(ChangeWidgetDescription { widget_description }): Json<ChangeWidgetDescription>,
+) -> impl IntoResponse {
+    match service
+        .change_widget_description(widget_id, widget_description)
+        .await
+    {
+        Ok(_) => StatusCode::ACCEPTED.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .unwrap_or_else(|e| panic!("failed to install Ctrl+C handler: {e}"))
+    };
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .unwrap_or_else(|e| panic!("failed to install signal handler: {e}"))
+            .recv()
+            .await;
+    };
+    tokio::select! {
+        _ = ctrl_c => println!("receive ctrl_c signal"),
+        _ = terminate => println!("receive terminate"),
+    }
+    println!("signal received, starting graceful shutdown");
 }

--- a/internal/kernel/Cargo.toml
+++ b/internal/kernel/Cargo.toml
@@ -3,6 +3,7 @@ name = "kernel"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+lib = { version = "0.1.0", path = "../lib" }
+thiserror = "1.0.56"
+ulid = "1.1.2"

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -6,7 +6,7 @@ use crate::event::WidgetEvent;
 use crate::Id;
 
 /// 部品 (Widget) の集約
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct WidgetAggregate {
     id: Id<WidgetAggregate>,
     name: String,

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,7 +1,7 @@
 use lib::Result;
 
 use crate::command::WidgetCommand;
-use crate::error::AggregateError;
+use crate::error::CommandError;
 use crate::event::WidgetEvent;
 use crate::Id;
 
@@ -37,19 +37,9 @@ impl WidgetAggregate {
 
     /// 集約にコマンドを実行する
     pub fn apply_command(self, command: WidgetCommand) -> Result<WidgetCommandState> {
-        let events = match command {
-            WidgetCommand::CreateWidget(event) => vec![event],
-            WidgetCommand::ChangeWidgetName(event) => vec![event],
-            WidgetCommand::ChangeWidgetDescription(event) => vec![event],
-        };
-        Ok(WidgetCommandState {
-            widget_id: self.id,
-            events,
-            aggregate_version: self
-                .version
-                .checked_add(1)
-                .ok_or(AggregateError::VersionUpdateLimitReached)?,
-        })
+        WidgetCommandExecutor::new(self, command)
+            .validate()
+            .execute()
     }
 }
 
@@ -75,5 +65,135 @@ impl WidgetCommandState {
     /// 集約のバージョン
     pub fn aggregate_version(&self) -> u64 {
         self.aggregate_version
+    }
+}
+
+/// 集約 (Aggregate) に対する `WidgetCommand` が有効か確認して `WidgetCommandState` を作成するビルダー
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct WidgetCommandExecutor<IsEventsValid, IsNameValid, IsDescriptionValid> {
+    aggregate: WidgetAggregate,
+    command: WidgetCommand,
+    is_events_valid: IsEventsValid,
+    is_widget_name_valid: IsNameValid,
+    is_widget_description_valid: IsDescriptionValid,
+}
+
+impl WidgetCommandExecutor<(), (), ()> {
+    fn new(aggregate: WidgetAggregate, command: WidgetCommand) -> Self {
+        Self {
+            aggregate,
+            command,
+            is_events_valid: (),
+            is_widget_name_valid: (),
+            is_widget_description_valid: (),
+        }
+    }
+
+    /// Aggregate に対するコマンドが有効か確認する
+    fn validate(self) -> WidgetCommandExecutor<bool, bool, bool> {
+        self.validate_events()
+            .validate_widget_name()
+            .validate_widget_description()
+    }
+}
+
+impl WidgetCommandExecutor<(), (), ()> {
+    /// コマンドに含まれるイベントが有効か確認する
+    fn validate_events(self) -> WidgetCommandExecutor<bool, (), ()> {
+        let is_events_valid = match &self.command {
+            WidgetCommand::CreateWidget(event) => {
+                matches!(event, WidgetEvent::WidgetCreated { .. })
+            }
+            WidgetCommand::ChangeWidgetName(event) => {
+                matches!(event, WidgetEvent::WidgetNameChanged { .. })
+            }
+            WidgetCommand::ChangeWidgetDescription(event) => {
+                matches!(event, WidgetEvent::WidgetDescriptionChanged { .. })
+            }
+        };
+        WidgetCommandExecutor {
+            aggregate: self.aggregate,
+            command: self.command,
+            is_events_valid,
+            is_widget_name_valid: self.is_widget_name_valid,
+            is_widget_description_valid: self.is_widget_description_valid,
+        }
+    }
+}
+
+impl<IsNameValid, IsDescriptionValid> WidgetCommandExecutor<bool, IsNameValid, IsDescriptionValid> {
+    /// イベントの部品の名前が有効か確認する
+    fn validate_widget_name(self) -> WidgetCommandExecutor<bool, bool, IsDescriptionValid> {
+        let is_widget_name_valid = match &self.command {
+            WidgetCommand::CreateWidget(event) | WidgetCommand::ChangeWidgetName(event) => {
+                match event {
+                    WidgetEvent::WidgetCreated { widget_name, .. }
+                    | WidgetEvent::WidgetNameChanged { widget_name, .. } => !widget_name.is_empty(),
+                    WidgetEvent::WidgetDescriptionChanged { .. } => true,
+                }
+            }
+            WidgetCommand::ChangeWidgetDescription(_) => true,
+        };
+        WidgetCommandExecutor {
+            aggregate: self.aggregate,
+            command: self.command,
+            is_events_valid: self.is_events_valid,
+            is_widget_name_valid,
+            is_widget_description_valid: self.is_widget_description_valid,
+        }
+    }
+
+    /// イベントの部品の説明が有効か確認する
+    fn validate_widget_description(self) -> WidgetCommandExecutor<bool, IsNameValid, bool> {
+        let is_widget_description_valid = match &self.command {
+            WidgetCommand::CreateWidget(event) | WidgetCommand::ChangeWidgetDescription(event) => {
+                match event {
+                    WidgetEvent::WidgetCreated {
+                        widget_description, ..
+                    }
+                    | WidgetEvent::WidgetDescriptionChanged {
+                        widget_description, ..
+                    } => !widget_description.is_empty(),
+                    WidgetEvent::WidgetNameChanged { .. } => true,
+                }
+            }
+            WidgetCommand::ChangeWidgetName(_) => true,
+        };
+        WidgetCommandExecutor {
+            aggregate: self.aggregate,
+            command: self.command,
+            is_events_valid: self.is_events_valid,
+            is_widget_name_valid: self.is_widget_name_valid,
+            is_widget_description_valid,
+        }
+    }
+}
+
+impl WidgetCommandExecutor<bool, bool, bool> {
+    /// コマンドの実行結果を返す
+    fn execute(self) -> Result<WidgetCommandState> {
+        if !self.is_events_valid {
+            return Err(Box::new(CommandError::InvalidEvent));
+        }
+        if !self.is_widget_name_valid {
+            return Err(Box::new(CommandError::InvalidWidgetName));
+        }
+        if !self.is_widget_description_valid {
+            return Err(Box::new(CommandError::InvalidWidgetDescription));
+        }
+        let events = match self.command {
+            WidgetCommand::CreateWidget(event)
+            | WidgetCommand::ChangeWidgetName(event)
+            | WidgetCommand::ChangeWidgetDescription(event) => vec![event],
+        };
+        Ok(WidgetCommandState {
+            widget_id: self.aggregate.id,
+            events,
+            aggregate_version: self
+                .aggregate
+                .version
+                .checked_add(1)
+                .ok_or(Box::new(CommandError::VersionUpdateLimitReached))?,
+        })
     }
 }

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -205,6 +205,7 @@ impl WidgetCommandExecutor<bool, bool, bool> {
 pub struct WidgetAggregateState {
     aggregate: WidgetAggregate,
     events: Vec<WidgetEvent>,
+    widget_id: Id<WidgetAggregate>,
     aggregate_version: u64,
 }
 
@@ -212,16 +213,19 @@ impl WidgetAggregateState {
     pub fn new(
         aggregate: WidgetAggregate,
         events: Vec<WidgetEvent>,
+        widget_id: Id<WidgetAggregate>,
         aggregate_version: u64,
     ) -> Self {
         Self {
             aggregate,
             events,
+            widget_id,
             aggregate_version,
         }
     }
 
     pub fn restore(mut self) -> Result<WidgetAggregate> {
+        self.aggregate.id = self.widget_id;
         for event in &self.events {
             match event {
                 WidgetEvent::WidgetCreated {

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -177,10 +177,10 @@ impl WidgetCommandExecutor<bool, bool, bool> {
             return Err("Invalid event found".into());
         }
         if !self.is_widget_name_valid {
-            return Err(Box::new(CommandError::InvalidWidgetName));
+            return Err(CommandError::InvalidWidgetName.into());
         }
         if !self.is_widget_description_valid {
-            return Err(Box::new(CommandError::InvalidWidgetDescription));
+            return Err(CommandError::InvalidWidgetDescription.into());
         }
         let aggregate_version = match self.command {
             WidgetCommand::CreateWidget(_) => 0,

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -181,6 +181,14 @@ impl WidgetCommandExecutor<bool, bool, bool> {
         if !self.is_widget_description_valid {
             return Err(Box::new(CommandError::InvalidWidgetDescription));
         }
+        let aggregate_version = match self.command {
+            WidgetCommand::CreateWidget(_) => 0,
+            _ => self
+                .aggregate
+                .version
+                .checked_add(1)
+                .ok_or(Box::new(CommandError::VersionUpdateLimitReached))?,
+        };
         let events = match self.command {
             WidgetCommand::CreateWidget(event)
             | WidgetCommand::ChangeWidgetName(event)
@@ -189,11 +197,7 @@ impl WidgetCommandExecutor<bool, bool, bool> {
         Ok(WidgetCommandState {
             widget_id: self.aggregate.id,
             events,
-            aggregate_version: self
-                .aggregate
-                .version
-                .checked_add(1)
-                .ok_or(Box::new(CommandError::VersionUpdateLimitReached))?,
+            aggregate_version,
         })
     }
 }

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,0 +1,79 @@
+use lib::Result;
+
+use crate::command::WidgetCommand;
+use crate::error::AggregateError;
+use crate::event::WidgetEvent;
+use crate::Id;
+
+/// 部品 (Widget) の集約
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WidgetAggregate {
+    id: Id<WidgetAggregate>,
+    name: String,
+    description: String,
+    version: u64,
+}
+
+impl WidgetAggregate {
+    /// 部品の id
+    pub fn id(&self) -> &Id<WidgetAggregate> {
+        &self.id
+    }
+
+    /// 部品の名前
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// 部品の説明
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// 集約のバージョン (= 更新回数)
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// 集約にコマンドを実行する
+    pub fn apply_command(self, command: WidgetCommand) -> Result<WidgetCommandState> {
+        let events = match command {
+            WidgetCommand::CreateWidget(event) => vec![event],
+            WidgetCommand::ChangeWidgetName(event) => vec![event],
+            WidgetCommand::ChangeWidgetDescription(event) => vec![event],
+        };
+        Ok(WidgetCommandState {
+            widget_id: self.id,
+            events,
+            aggregate_version: self
+                .version
+                .checked_add(1)
+                .ok_or(AggregateError::VersionUpdateLimitReached)?,
+        })
+    }
+}
+
+/// 集約 (Aggregate) に対するコマンドの処理を成功して保存可能になった状態
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WidgetCommandState {
+    widget_id: Id<WidgetAggregate>,
+    events: Vec<WidgetEvent>,
+    aggregate_version: u64,
+}
+
+impl WidgetCommandState {
+    /// 部品の id
+    pub fn widget_id(&self) -> &Id<WidgetAggregate> {
+        &self.widget_id
+    }
+
+    /// 部品に対するコマンド
+    pub fn events(&self) -> &[WidgetEvent] {
+        &self.events
+    }
+
+    /// 集約のバージョン
+    pub fn aggregate_version(&self) -> u64 {
+        self.aggregate_version
+    }
+}

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -1,7 +1,7 @@
 use lib::Result;
 
 use crate::command::WidgetCommand;
-use crate::error::{AggregateError, CommandError};
+use crate::error::CommandError;
 use crate::event::WidgetEvent;
 use crate::Id;
 
@@ -173,7 +173,8 @@ impl WidgetCommandExecutor<bool, bool, bool> {
     /// コマンドの実行結果を返す
     fn execute(self) -> Result<WidgetCommandState> {
         if !self.is_events_valid {
-            return Err(Box::new(CommandError::InvalidEvent));
+            // コマンドに不正なイベントが含まれるときのエラー
+            return Err("Invalid event found".into());
         }
         if !self.is_widget_name_valid {
             return Err(Box::new(CommandError::InvalidWidgetName));
@@ -187,7 +188,7 @@ impl WidgetCommandExecutor<bool, bool, bool> {
                 .aggregate
                 .version
                 .checked_add(1)
-                .ok_or(Box::new(CommandError::VersionUpdateLimitReached))?,
+                .ok_or("Cannot update Aggregate version")?,
         };
         let events = match self.command {
             WidgetCommand::CreateWidget(event)
@@ -249,7 +250,8 @@ impl WidgetAggregateState {
             }
         }
         if self.aggregate.version != self.aggregate_version {
-            return Err(Box::new(AggregateError::NotMatchVersion));
+            // イベントから Aggregate を復元時のバージョンが合わないときのエラー
+            return Err("Not match aggregate version".into());
         }
         Ok(self.aggregate)
     }

--- a/internal/kernel/src/command.rs
+++ b/internal/kernel/src/command.rs
@@ -1,4 +1,5 @@
 use crate::event::WidgetEvent;
+use crate::Id;
 
 /// 部品 (Widget) に対するコマンド
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -9,4 +10,31 @@ pub enum WidgetCommand {
     ChangeWidgetName(WidgetEvent),
     /// 部品の説明を変更する
     ChangeWidgetDescription(WidgetEvent),
+}
+
+impl WidgetCommand {
+    /// 部品を新しく作成する
+    pub fn create_widget(widget_name: String, widget_description: String) -> Self {
+        Self::CreateWidget(WidgetEvent::WidgetCreated {
+            id: Id::generate(),
+            widget_name,
+            widget_description,
+        })
+    }
+
+    /// 部品の名前を変更する
+    pub fn change_widget_name(widget_name: String) -> Self {
+        Self::ChangeWidgetName(WidgetEvent::WidgetNameChanged {
+            id: Id::generate(),
+            widget_name,
+        })
+    }
+
+    /// 部品の説明を変更する
+    pub fn change_widget_description(widget_description: String) -> Self {
+        Self::ChangeWidgetDescription(WidgetEvent::WidgetDescriptionChanged {
+            id: Id::generate(),
+            widget_description,
+        })
+    }
 }

--- a/internal/kernel/src/command.rs
+++ b/internal/kernel/src/command.rs
@@ -1,0 +1,12 @@
+use crate::event::WidgetEvent;
+
+/// 部品 (Widget) に対するコマンド
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WidgetCommand {
+    /// 部品を新しく作成する
+    CreateWidget(WidgetEvent),
+    /// 部品の名前を変更する
+    ChangeWidgetName(WidgetEvent),
+    /// 部品の説明を変更する
+    ChangeWidgetDescription(WidgetEvent),
+}

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -16,3 +16,13 @@ pub enum CommandError {
     #[error("Invalid description for the widget")]
     InvalidWidgetDescription,
 }
+
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AggregateError {
+    /// Aggregate が既に更新さているときのエラー
+    #[error("Aggregate is already updated")]
+    Conflict,
+    /// イベントから Aggregate を復元時のバージョンが合わないときのエラー
+    #[error("Not match aggregate version")]
+    NotMatchVersion,
+}

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AggregateError {
+    #[error("Cannot update Aggregate version")]
+    VersionUpdateLimitReached,
+}

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -1,7 +1,18 @@
 use thiserror::Error;
 
+/// コマンドの実行に失敗したことを表す
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum AggregateError {
+pub enum CommandError {
+    /// Aggregate のバージョンが上限を超えたときのエラー
     #[error("Cannot update Aggregate version")]
     VersionUpdateLimitReached,
+    /// コマンドに不正なイベントが含まれるときのエラー
+    #[error("Invalid event found")]
+    InvalidEvent,
+    /// イベントに含まれる部品の名前が不正なフォーマットのときのエラー
+    #[error("Invalid name for the widget")]
+    InvalidWidgetName,
+    /// イベントに含まれる部品の説明が不正なフォーマットのときのエラー
+    #[error("Invalid description for the widget")]
+    InvalidWidgetDescription,
 }

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -3,12 +3,6 @@ use thiserror::Error;
 /// コマンドの実行に失敗したことを表す
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CommandError {
-    /// Aggregate のバージョンが上限を超えたときのエラー
-    #[error("Cannot update Aggregate version")]
-    VersionUpdateLimitReached,
-    /// コマンドに不正なイベントが含まれるときのエラー
-    #[error("Invalid event found")]
-    InvalidEvent,
     /// イベントに含まれる部品の名前が不正なフォーマットのときのエラー
     #[error("Invalid name for the widget")]
     InvalidWidgetName,
@@ -22,7 +16,4 @@ pub enum AggregateError {
     /// Aggregate が既に更新さているときのエラー
     #[error("Aggregate is already updated")]
     Conflict,
-    /// イベントから Aggregate を復元時のバージョンが合わないときのエラー
-    #[error("Not match aggregate version")]
-    NotMatchVersion,
 }

--- a/internal/kernel/src/event.rs
+++ b/internal/kernel/src/event.rs
@@ -24,6 +24,6 @@ pub enum WidgetEvent {
         /// イベントの id
         id: Id<WidgetEvent>,
         /// 部品の名前
-        description: String,
+        widget_description: String,
     },
 }

--- a/internal/kernel/src/event.rs
+++ b/internal/kernel/src/event.rs
@@ -1,0 +1,29 @@
+use crate::Id;
+
+/// 部品 (Widget) に発生するイベント
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WidgetEvent {
+    /// 部品を新しく作成する
+    WidgetCreated {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        widget_name: String,
+        /// 部品の説明
+        widget_description: String,
+    },
+    /// 部品の名前を変更する
+    WidgetNameChanged {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        widget_name: String,
+    },
+    /// 部品の説明を変更する
+    WidgetDescriptionChanged {
+        /// イベントの id
+        id: Id<WidgetEvent>,
+        /// 部品の名前
+        description: String,
+    },
+}

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
+use lib::Error;
 use ulid::Ulid;
 
 pub mod aggregate;
@@ -32,7 +33,7 @@ impl<T> Default for Id<T> {
 }
 
 impl<T> FromStr for Id<T> {
-    type Err = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -6,6 +6,7 @@ pub mod aggregate;
 pub mod command;
 pub mod error;
 pub mod event;
+pub mod processor;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id<T> {

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
@@ -38,5 +39,11 @@ impl<T> FromStr for Id<T> {
             value: Ulid::from_str(s)?,
             _maker: PhantomData,
         })
+    }
+}
+
+impl<T> Display for Id<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value.to_string())
     }
 }

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -1,14 +1,14 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use std::marker::PhantomData;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+use ulid::Ulid;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+pub mod aggregate;
+pub mod command;
+pub mod error;
+pub mod event;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Id<T> {
+    value: Ulid,
+    _maker: PhantomData<T>,
 }

--- a/internal/kernel/src/lib.rs
+++ b/internal/kernel/src/lib.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::str::FromStr;
 
 use ulid::Ulid;
 
@@ -12,4 +13,30 @@ pub mod processor;
 pub struct Id<T> {
     value: Ulid,
     _maker: PhantomData<T>,
+}
+
+impl<T> Id<T> {
+    pub fn generate() -> Self {
+        Self {
+            value: Ulid::new(),
+            _maker: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for Id<T> {
+    fn default() -> Self {
+        Self::generate()
+    }
+}
+
+impl<T> FromStr for Id<T> {
+    type Err = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            value: Ulid::from_str(s)?,
+            _maker: PhantomData,
+        })
+    }
 }

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -1,0 +1,23 @@
+use lib::Result;
+
+use crate::aggregate::{WidgetAggregate, WidgetCommandState};
+use crate::Id;
+
+/// 集約を永続化する処理のインターフェイス
+pub trait CommandProcessor {
+    /// 部品の集約を新しく作成する
+    fn create_widget_aggregate(
+        &self,
+        command_state: WidgetCommandState,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    /// 部品の集約を取得する
+    fn get_widget_aggregate(
+        &self,
+        widget_id: Id<WidgetAggregate>,
+    ) -> impl std::future::Future<Output = Result<WidgetAggregate>> + Send;
+    /// 部品の集約を更新する
+    fn update_widget_aggregate(
+        &self,
+        command_state: WidgetCommandState,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+}

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -14,7 +14,7 @@ pub trait CommandProcessor {
     fn get_widget_aggregate(
         &self,
         widget_id: Id<WidgetAggregate>,
-    ) -> impl std::future::Future<Output = Result<WidgetAggregate>> + Send;
+    ) -> impl std::future::Future<Output = Result<Option<WidgetAggregate>>> + Send;
     /// 部品の集約を更新する
     fn update_widget_aggregate(
         &self,

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,2 +1,12 @@
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type Result<T> = core::result::Result<T, Error>;
+
+pub fn database_url() -> String {
+    format!(
+        "mysql://{}:{}@127.0.0.1:{}/{}",
+        option_env!("MYSQL_USERNAME").unwrap_or("root"),
+        option_env!("MYSQL_PASSWORD").unwrap_or("root"),
+        option_env!("MYSQL_PORT").unwrap_or("3306"),
+        option_env!("MYSQL_DATABASE").unwrap_or("widget")
+    )
+}

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,1 +1,2 @@
-pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type Result<T> = core::result::Result<T, Error>;

--- a/migrations/20240210132634_create_aggregate.sql
+++ b/migrations/20240210132634_create_aggregate.sql
@@ -1,0 +1,7 @@
+CREATE TABLE aggregate (
+    widget_id VARCHAR(255) NOT NULL,
+    last_events JSON NOT NULL,
+    aggregate_version BIGINT UNSIGNED NOT NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (widget_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/migrations/20240210132646_create_event.sql
+++ b/migrations/20240210132646_create_event.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS event (
+    event_id VARCHAR(255) NOT NULL,
+    widget_id VARCHAR(255) NOT NULL,
+    event_name VARCHAR(255) NOT NULL,
+    payload JSON NOT NULL,
+    PRIMARY KEY (event_id),
+    INDEX idx_widget_id (widget_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -1,0 +1,18 @@
+use lib::Result;
+use sqlx::{Connection, MySqlConnection};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut pool = MySqlConnection::connect("mysql://root:root@127.0.0.1:3306/widget").await?;
+    sqlx::query(include_str!(
+        "../../migrations/20240210132634_create_aggregate.sql"
+    ))
+    .execute(&mut pool)
+    .await?;
+    sqlx::query(include_str!(
+        "../../migrations/20240210132646_create_event.sql"
+    ))
+    .execute(&mut pool)
+    .await?;
+    Ok(())
+}

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -1,9 +1,9 @@
-use lib::Result;
+use lib::{database_url, Result};
 use sqlx::{Connection, MySqlConnection};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut pool = MySqlConnection::connect("mysql://root:root@127.0.0.1:3306/widget").await?;
+    let mut pool = MySqlConnection::connect(&database_url()).await?;
     sqlx::query(include_str!(
         "../../migrations/20240210132634_create_aggregate.sql"
     ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,14 @@
-fn main() {
-    println!("Hello, world!");
+use adapter::persistence::connect;
+use adapter::repository::WidgetRepository;
+use app::WidgetServiceImpl;
+use driver::Server;
+use lib::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let pool = connect("mysql://root:root@127.0.0.1:3306/widget").await?;
+    let repository = WidgetRepository::new(pool);
+    let service = WidgetServiceImpl::new(repository);
+    let server = Server::new("0.0.0.0:8080", service.into());
+    server.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@ use adapter::persistence::connect;
 use adapter::repository::WidgetRepository;
 use app::WidgetServiceImpl;
 use driver::Server;
-use lib::Result;
+use lib::{database_url, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let pool = connect("mysql://root:root@127.0.0.1:3306/widget").await?;
+    let pool = connect(&database_url()).await?;
     let repository = WidgetRepository::new(pool);
     let service = WidgetServiceImpl::new(repository);
     let server = Server::new("0.0.0.0:8080", service.into());


### PR DESCRIPTION
## Overview

Amazon Web Services ブログの [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) を参考に Rust でイベントソーシングを実現する

### [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) からの変更点

- DynamoDB ではなく MySQL をデータストアとする
- MySQL を利用するので集約の新規作成と更新が別の関数となった
