### PR TITLE
feat: 各層をカスタムエラーで返すようにする

### DIFF
--- a/internal/adapter/src/persistence.rs
+++ b/internal/adapter/src/persistence.rs
@@ -1,10 +1,10 @@
-use lib::Result;
+use lib::Error;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::{MySql, Pool};
 
 pub type ConnectionPool = Pool<MySql>;
 
-pub async fn connect(url: &str) -> Result<ConnectionPool> {
+pub async fn connect(url: &str) -> Result<ConnectionPool, Error> {
     Ok(MySqlPoolOptions::new()
         .max_connections(20)
         .connect(url)

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -2,7 +2,6 @@ use kernel::aggregate::WidgetAggregate;
 use kernel::error::AggregateError;
 use kernel::event::WidgetEvent;
 use kernel::processor::CommandProcessor;
-use lib::Result;
 
 use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel, WidgetEventModels};
 use crate::persistence::ConnectionPool;
@@ -21,9 +20,13 @@ impl CommandProcessor for WidgetRepository {
     async fn create_widget_aggregate(
         &self,
         command_state: kernel::aggregate::WidgetCommandState,
-    ) -> Result<()> {
+    ) -> Result<(), AggregateError> {
         let model: WidgetAggregateModel = command_state.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         sqlx::query(
             "INSERT INTO aggregate (widget_id, last_events, aggregate_version) VALUES (?, ?, ?)",
         )
@@ -31,15 +34,18 @@ impl CommandProcessor for WidgetRepository {
         .bind(model.last_events())
         .bind(model.aggregate_version())
         .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
+        .await
+        .map_err(|e| AggregateError::Unknow(e.into()))?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         Ok(())
     }
 
     async fn get_widget_aggregate(
         &self,
         widget_id: kernel::Id<kernel::aggregate::WidgetAggregate>,
-    ) -> Result<Option<kernel::aggregate::WidgetAggregate>> {
+    ) -> Result<Option<kernel::aggregate::WidgetAggregate>, AggregateError> {
         // Aggregate テーブルから関連する集約項目を取得する
         let model: WidgetAggregateModel =
             match sqlx::query_as("SELECT * FROM aggregate WHERE widget_id = ?")
@@ -50,7 +56,7 @@ impl CommandProcessor for WidgetRepository {
                 Ok(x) => x,
                 Err(e) => match e {
                     sqlx::Error::RowNotFound => return Ok(None),
-                    _ => return Err(e.into()),
+                    _ => return Err(AggregateError::Unknow(e.into())),
                 },
             };
         // ビジネスロジックの適用の前にイベントと集約のデータが正しい状態にあることを保証するために
@@ -58,7 +64,11 @@ impl CommandProcessor for WidgetRepository {
         let widget_id = widget_id.to_string();
         let aggregate_version = model.aggregate_version();
         let WidgetEventModels(models) = model.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         for model in models {
             let result = sqlx::query(
                 "INSERT INTO event (event_id, widget_id, event_name, payload) VALUES (?, ?, ?, ?)",
@@ -73,40 +83,49 @@ impl CommandProcessor for WidgetRepository {
                 match e.as_database_error() {
                     // NOTE: イベントが既に存在してもイベントは変更不可能なのでエラーを無視する
                     Some(e) if e.is_unique_violation() => continue,
-                    _ => return Err(e.into()),
+                    _ => return Err(AggregateError::Unknow(e.into())),
                 }
             }
         }
-        tx.commit().await?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         // 関連するすべてのイベントを読み込んで集約の状態を復元する
         let models: Vec<WidgetEventModel> =
             // NOTE: 時系列にしたがってイベントから集約を復元するために event_id の昇順でソートする
             sqlx::query_as("SELECT * FROM event WHERE widget_id = ? ORDER BY event_id ASC")
                 .bind(&widget_id)
                 .fetch_all(&self.pool)
-                .await?;
-        let mappers: Vec<Result<WidgetEventMapper>> =
+                .await
+                .map_err(|e| AggregateError::Unknow(e.into()))?;
+        let mappers: Vec<Result<WidgetEventMapper, lib::Error>> =
             models.into_iter().map(|x| x.try_into()).collect();
         if mappers.iter().any(|x| x.is_err()) {
-            return Err("Parse mapper from model".into());
+            return Err(AggregateError::Unknow("Parse mapper from model".into()));
         }
-        let events: Vec<Result<WidgetEvent>> =
+        let events: Vec<Result<WidgetEvent, lib::Error>> =
             mappers.into_iter().map(|x| x.unwrap().try_into()).collect();
         if events.iter().any(|x| x.is_err()) {
-            return Err("Parse event from mapper".into());
+            return Err(AggregateError::Unknow("Parse event from mapper".into()));
         }
         let events: Vec<_> = events.into_iter().map(|x| x.unwrap()).collect();
         Ok(Some(
-            WidgetAggregate::new(widget_id.parse()?).load_events(events, aggregate_version)?,
+            WidgetAggregate::new(widget_id.parse()?)
+                .load_events(events, aggregate_version)
+                .map_err(|e| AggregateError::Unknow(e.into()))?,
         ))
     }
 
     async fn update_widget_aggregate(
         &self,
         command_state: kernel::aggregate::WidgetCommandState,
-    ) -> Result<()> {
+    ) -> Result<(), AggregateError> {
         let model: WidgetAggregateModel = command_state.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         let result = sqlx::query(
             "
             UPDATE
@@ -122,12 +141,15 @@ impl CommandProcessor for WidgetRepository {
         .bind(model.widget_id())
         .bind(model.aggregate_version().saturating_sub(1))
         .execute(&mut *tx)
-        .await?;
+        .await
+        .map_err(|e| AggregateError::Unknow(e.into()))?;
         // NOTE: 同時接続で既に Aggregate が更新されていた場合はエラーを返す
         if result.rows_affected() == 0 {
-            return Err(AggregateError::Conflict.into());
+            return Err(AggregateError::Conflict);
         }
-        tx.commit().await?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         Ok(())
     }
 }

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -2,6 +2,7 @@ use kernel::aggregate::WidgetAggregate;
 use kernel::error::AggregateError;
 use kernel::event::WidgetEvent;
 use kernel::processor::CommandProcessor;
+use lib::Error;
 
 use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel, WidgetEventModels};
 use crate::persistence::ConnectionPool;
@@ -98,12 +99,12 @@ impl CommandProcessor for WidgetRepository {
                 .fetch_all(&self.pool)
                 .await
                 .map_err(|e| AggregateError::Unknow(e.into()))?;
-        let mappers: Vec<Result<WidgetEventMapper, lib::Error>> =
+        let mappers: Vec<Result<WidgetEventMapper, Error>> =
             models.into_iter().map(|x| x.try_into()).collect();
         if mappers.iter().any(|x| x.is_err()) {
             return Err(AggregateError::Unknow("Parse mapper from model".into()));
         }
-        let events: Vec<Result<WidgetEvent, lib::Error>> =
+        let events: Vec<Result<WidgetEvent, Error>> =
             mappers.into_iter().map(|x| x.unwrap().try_into()).collect();
         if events.iter().any(|x| x.is_err()) {
             return Err(AggregateError::Unknow("Parse event from mapper".into()));

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -4,6 +4,7 @@ use kernel::aggregate::WidgetAggregate;
 use kernel::command::WidgetCommand;
 use kernel::error::{AggregateError, ApplyCommandError};
 use kernel::processor::CommandProcessor;
+use lib::Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -18,7 +19,7 @@ pub enum WidgetServiceError {
     #[error("Invalid value")]
     InvalidValue,
     #[error("error")]
-    Unknow(#[from] lib::Error),
+    Unknow(#[from] Error),
 }
 
 impl From<ApplyCommandError> for WidgetServiceError {

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -36,6 +36,7 @@ impl From<AggregateError> for WidgetServiceError {
     fn from(value: AggregateError) -> Self {
         match value {
             AggregateError::Conflict => Self::AggregateConfilict,
+            AggregateError::NotFound => Self::AggregateNotFound,
             AggregateError::Unknow(e) => Self::Unknow(e),
         }
     }
@@ -104,8 +105,7 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
             let aggregate = self
                 .command
                 .get_widget_aggregate(widget_id.parse()?)
-                .await?
-                .ok_or(WidgetServiceError::AggregateNotFound)?;
+                .await?;
             let command = WidgetCommand::ChangeWidgetName {
                 widget_name: widget_name.clone(),
             };
@@ -139,8 +139,7 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
             let aggregate = self
                 .command
                 .get_widget_aggregate(widget_id.parse()?)
-                .await?
-                .ok_or(WidgetServiceError::AggregateNotFound)?;
+                .await?;
             let command = WidgetCommand::ChangeWidgetDescription {
                 widget_description: widget_description.clone(),
             };

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -87,9 +87,7 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
             widget_name,
             widget_description,
         };
-        let command_state = aggregate
-            .apply_command(command)
-            .map_err(WidgetServiceError::from)?;
+        let command_state = aggregate.apply_command(command)?;
         self.command.create_widget_aggregate(command_state).await?;
         Ok(widget_id)
     }
@@ -109,16 +107,14 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
             let command = WidgetCommand::ChangeWidgetName {
                 widget_name: widget_name.clone(),
             };
-            let command_state = aggregate
-                .apply_command(command)
-                .map_err(WidgetServiceError::from)?;
+            let command_state = aggregate.apply_command(command)?;
             match self.command.update_widget_aggregate(command_state).await {
                 Ok(_) => break,
                 Err(e) => match e {
                     AggregateError::Conflict if retry_count.le(&MAX_RETRY_COUNT) => {
                         retry_count += 1
                     }
-                    _ => return Err(WidgetServiceError::from(e)),
+                    _ => return Err(e.into()),
                 },
             }
         }
@@ -143,16 +139,14 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
             let command = WidgetCommand::ChangeWidgetDescription {
                 widget_description: widget_description.clone(),
             };
-            let command_state = aggregate
-                .apply_command(command)
-                .map_err(WidgetServiceError::from)?;
+            let command_state = aggregate.apply_command(command)?;
             match self.command.update_widget_aggregate(command_state).await {
                 Ok(_) => break,
                 Err(e) => match e {
                     AggregateError::Conflict if retry_count.le(&MAX_RETRY_COUNT) => {
                         retry_count += 1
                     }
-                    _ => return Err(WidgetServiceError::from(e)),
+                    _ => return Err(e.into()),
                 },
             }
         }

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -111,6 +111,9 @@ fn handling_service_error(err: Error) -> impl IntoResponse {
             WidgetServiceError::AggregateNotFound => StatusCode::NOT_FOUND.into_response(),
             WidgetServiceError::AggregateConfilict => StatusCode::CONFLICT.into_response(),
             WidgetServiceError::InvalidValue => StatusCode::BAD_REQUEST.into_response(),
+            WidgetServiceError::Unknow(e) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+            }
         },
         None => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     }

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -105,17 +105,14 @@ async fn change_widget_description<S: WidgetService>(
     }
 }
 
-fn handling_service_error(err: Error) -> impl IntoResponse {
-    match err.downcast_ref::<WidgetServiceError>() {
-        Some(e) => match e {
-            WidgetServiceError::AggregateNotFound => StatusCode::NOT_FOUND.into_response(),
-            WidgetServiceError::AggregateConfilict => StatusCode::CONFLICT.into_response(),
-            WidgetServiceError::InvalidValue => StatusCode::BAD_REQUEST.into_response(),
-            WidgetServiceError::Unknow(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-            }
-        },
-        None => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+fn handling_service_error(err: WidgetServiceError) -> impl IntoResponse {
+    match err {
+        WidgetServiceError::AggregateNotFound => StatusCode::NOT_FOUND.into_response(),
+        WidgetServiceError::AggregateConfilict => StatusCode::CONFLICT.into_response(),
+        WidgetServiceError::InvalidValue => StatusCode::BAD_REQUEST.into_response(),
+        WidgetServiceError::Unknow(e) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
     }
 }
 

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -1,3 +1,4 @@
+use lib::Error;
 use thiserror::Error;
 
 /// コマンドの実行に失敗したことを表す
@@ -32,5 +33,5 @@ pub enum AggregateError {
     NotFound,
     /// その他のエラー
     #[error(transparent)]
-    Unknow(#[from] lib::Error),
+    Unknow(#[from] Error),
 }

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -2,13 +2,24 @@ use thiserror::Error;
 
 /// コマンドの実行に失敗したことを表す
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CommandError {
+pub enum ApplyCommandError {
     /// イベントに含まれる部品の名前が不正なフォーマットのときのエラー
     #[error("Invalid name for the widget")]
     InvalidWidgetName,
     /// イベントに含まれる部品の説明が不正なフォーマットのときのエラー
     #[error("Invalid description for the widget")]
     InvalidWidgetDescription,
+    /// イベントに含まれる部品の説明が不正なフォーマットのときのエラー
+    #[error("Cannot update Aggregate version")]
+    VersionOverflow,
+}
+
+/// イベントから復元時のエラー
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LoadEventError {
+    /// Aggregate 復元時に version が実体と一致しないときのエラー
+    #[error("Not match aggregate version")]
+    NotMatchVersion,
 }
 
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -27,6 +27,9 @@ pub enum AggregateError {
     /// Aggregate が既に更新さているときのエラー
     #[error("Aggregate is already updated")]
     Conflict,
+    /// Aggregate が存在しないときのエラー
+    #[error("Aggregate not found")]
+    NotFound,
     /// その他のエラー
     #[error(transparent)]
     Unknow(#[from] lib::Error),

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -22,9 +22,12 @@ pub enum LoadEventError {
     NotMatchVersion,
 }
 
-#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Error, Debug)]
 pub enum AggregateError {
     /// Aggregate が既に更新さているときのエラー
     #[error("Aggregate is already updated")]
     Conflict,
+    /// その他のエラー
+    #[error(transparent)]
+    Unknow(#[from] lib::Error),
 }

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -13,7 +13,7 @@ pub trait CommandProcessor {
     fn get_widget_aggregate(
         &self,
         widget_id: Id<WidgetAggregate>,
-    ) -> impl std::future::Future<Output = Result<Option<WidgetAggregate>, AggregateError>> + Send;
+    ) -> impl std::future::Future<Output = Result<WidgetAggregate, AggregateError>> + Send;
     /// 部品の集約を更新する
     fn update_widget_aggregate(
         &self,

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -1,6 +1,5 @@
-use lib::Result;
-
 use crate::aggregate::{WidgetAggregate, WidgetCommandState};
+use crate::error::AggregateError;
 use crate::Id;
 
 /// 集約を永続化する処理のインターフェイス
@@ -9,15 +8,15 @@ pub trait CommandProcessor {
     fn create_widget_aggregate(
         &self,
         command_state: WidgetCommandState,
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), AggregateError>> + Send;
     /// 部品の集約を取得する
     fn get_widget_aggregate(
         &self,
         widget_id: Id<WidgetAggregate>,
-    ) -> impl std::future::Future<Output = Result<Option<WidgetAggregate>>> + Send;
+    ) -> impl std::future::Future<Output = Result<Option<WidgetAggregate>, AggregateError>> + Send;
     /// 部品の集約を更新する
     fn update_widget_aggregate(
         &self,
         command_state: WidgetCommandState,
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), AggregateError>> + Send;
 }

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,5 +1,4 @@
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-pub type Result<T> = core::result::Result<T, Error>;
 
 pub fn database_url() -> String {
     format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use adapter::persistence::connect;
 use adapter::repository::WidgetRepository;
 use app::WidgetServiceImpl;
 use driver::Server;
-use lib::{database_url, Result};
+use lib::{database_url, Error};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Error> {
     let pool = connect(&database_url()).await?;
     let repository = WidgetRepository::new(pool);
     let service = WidgetServiceImpl::new(repository);


### PR DESCRIPTION
## Overview

ほとんどの `Result` を返す関数で `lib::Result` つまり `Result<T, Box<dyn std::error:: Error + Send + Sync + 'static>>` を返すようにしていたが各層でエラーをダウンキャストして比較する必要があったためエラーハンドリングが煩雑になっていた
そこでエラーハンドリング処理を簡潔にする目的で各関数で独自のエラーを定義した
