### PR TITLE
change: コードの見通しを良くする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"

--- a/internal/adapter/src/model.rs
+++ b/internal/adapter/src/model.rs
@@ -66,12 +66,7 @@ impl WidgetEventModel {
     }
 }
 
-/// `WidgetEventModel` の配列を NewType パターンで表現する
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WidgetEventModels(pub(crate) Vec<WidgetEventModel>);
-
-/// `WidgetAggregateModel` の last_events から `WidgetEventModel` の配列に変換する
-impl TryFrom<WidgetAggregateModel> for WidgetEventModels {
+impl TryFrom<WidgetAggregateModel> for Vec<WidgetEventModel> {
     type Error = Error;
 
     fn try_from(value: WidgetAggregateModel) -> Result<Self, Self::Error> {
@@ -85,7 +80,7 @@ impl TryFrom<WidgetAggregateModel> for WidgetEventModels {
             };
             models.push(model);
         }
-        Ok(Self(models))
+        Ok(models)
     }
 }
 

--- a/internal/adapter/src/persistence.rs
+++ b/internal/adapter/src/persistence.rs
@@ -1,10 +1,10 @@
-use lib::Result;
+use lib::Error;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::{MySql, Pool};
 
 pub type ConnectionPool = Pool<MySql>;
 
-pub async fn connect(url: &str) -> Result<ConnectionPool> {
+pub async fn connect(url: &str) -> Result<ConnectionPool, Error> {
     Ok(MySqlPoolOptions::new()
         .max_connections(20)
         .connect(url)

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -1,4 +1,4 @@
-use kernel::aggregate::{WidgetAggregate, WidgetAggregateState};
+use kernel::aggregate::WidgetAggregate;
 use kernel::error::AggregateError;
 use kernel::event::WidgetEvent;
 use kernel::processor::CommandProcessor;
@@ -97,13 +97,7 @@ impl CommandProcessor for WidgetRepository {
         }
         let events: Vec<_> = events.into_iter().map(|x| x.unwrap()).collect();
         Ok(Some(
-            WidgetAggregateState::new(
-                WidgetAggregate::default(),
-                events,
-                widget_id.parse()?,
-                aggregate_version,
-            )
-            .restore()?,
+            WidgetAggregate::new(widget_id.parse()?).load_events(events, aggregate_version)?,
         ))
     }
 

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -2,7 +2,7 @@ use kernel::aggregate::WidgetAggregate;
 use kernel::error::AggregateError;
 use kernel::event::WidgetEvent;
 use kernel::processor::CommandProcessor;
-use lib::Result;
+use lib::Error;
 
 use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel, WidgetEventModels};
 use crate::persistence::ConnectionPool;
@@ -21,9 +21,13 @@ impl CommandProcessor for WidgetRepository {
     async fn create_widget_aggregate(
         &self,
         command_state: kernel::aggregate::WidgetCommandState,
-    ) -> Result<()> {
+    ) -> Result<(), AggregateError> {
         let model: WidgetAggregateModel = command_state.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         sqlx::query(
             "INSERT INTO aggregate (widget_id, last_events, aggregate_version) VALUES (?, ?, ?)",
         )
@@ -31,15 +35,18 @@ impl CommandProcessor for WidgetRepository {
         .bind(model.last_events())
         .bind(model.aggregate_version())
         .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
+        .await
+        .map_err(|e| AggregateError::Unknow(e.into()))?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         Ok(())
     }
 
     async fn get_widget_aggregate(
         &self,
         widget_id: kernel::Id<kernel::aggregate::WidgetAggregate>,
-    ) -> Result<Option<kernel::aggregate::WidgetAggregate>> {
+    ) -> Result<kernel::aggregate::WidgetAggregate, AggregateError> {
         // Aggregate テーブルから関連する集約項目を取得する
         let model: WidgetAggregateModel =
             match sqlx::query_as("SELECT * FROM aggregate WHERE widget_id = ?")
@@ -49,8 +56,8 @@ impl CommandProcessor for WidgetRepository {
             {
                 Ok(x) => x,
                 Err(e) => match e {
-                    sqlx::Error::RowNotFound => return Ok(None),
-                    _ => return Err(e.into()),
+                    sqlx::Error::RowNotFound => return Err(AggregateError::NotFound),
+                    _ => return Err(AggregateError::Unknow(e.into())),
                 },
             };
         // ビジネスロジックの適用の前にイベントと集約のデータが正しい状態にあることを保証するために
@@ -58,7 +65,11 @@ impl CommandProcessor for WidgetRepository {
         let widget_id = widget_id.to_string();
         let aggregate_version = model.aggregate_version();
         let WidgetEventModels(models) = model.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         for model in models {
             let result = sqlx::query(
                 "INSERT INTO event (event_id, widget_id, event_name, payload) VALUES (?, ?, ?, ?)",
@@ -73,40 +84,47 @@ impl CommandProcessor for WidgetRepository {
                 match e.as_database_error() {
                     // NOTE: イベントが既に存在してもイベントは変更不可能なのでエラーを無視する
                     Some(e) if e.is_unique_violation() => continue,
-                    _ => return Err(e.into()),
+                    _ => return Err(AggregateError::Unknow(e.into())),
                 }
             }
         }
-        tx.commit().await?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         // 関連するすべてのイベントを読み込んで集約の状態を復元する
         let models: Vec<WidgetEventModel> =
             // NOTE: 時系列にしたがってイベントから集約を復元するために event_id の昇順でソートする
             sqlx::query_as("SELECT * FROM event WHERE widget_id = ? ORDER BY event_id ASC")
                 .bind(&widget_id)
                 .fetch_all(&self.pool)
-                .await?;
-        let mappers: Vec<Result<WidgetEventMapper>> =
+                .await
+                .map_err(|e| AggregateError::Unknow(e.into()))?;
+        let mappers: Vec<Result<WidgetEventMapper, Error>> =
             models.into_iter().map(|x| x.try_into()).collect();
         if mappers.iter().any(|x| x.is_err()) {
-            return Err("Parse mapper from model".into());
+            return Err(AggregateError::Unknow("Parse mapper from model".into()));
         }
-        let events: Vec<Result<WidgetEvent>> =
+        let events: Vec<Result<WidgetEvent, Error>> =
             mappers.into_iter().map(|x| x.unwrap().try_into()).collect();
         if events.iter().any(|x| x.is_err()) {
-            return Err("Parse event from mapper".into());
+            return Err(AggregateError::Unknow("Parse event from mapper".into()));
         }
         let events: Vec<_> = events.into_iter().map(|x| x.unwrap()).collect();
-        Ok(Some(
-            WidgetAggregate::new(widget_id.parse()?).load_events(events, aggregate_version)?,
-        ))
+        WidgetAggregate::new(widget_id.parse()?)
+            .load_events(events, aggregate_version)
+            .map_err(|e| AggregateError::Unknow(e.into()))
     }
 
     async fn update_widget_aggregate(
         &self,
         command_state: kernel::aggregate::WidgetCommandState,
-    ) -> Result<()> {
+    ) -> Result<(), AggregateError> {
         let model: WidgetAggregateModel = command_state.try_into()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         let result = sqlx::query(
             "
             UPDATE
@@ -122,12 +140,15 @@ impl CommandProcessor for WidgetRepository {
         .bind(model.widget_id())
         .bind(model.aggregate_version().saturating_sub(1))
         .execute(&mut *tx)
-        .await?;
+        .await
+        .map_err(|e| AggregateError::Unknow(e.into()))?;
         // NOTE: 同時接続で既に Aggregate が更新されていた場合はエラーを返す
         if result.rows_affected() == 0 {
-            return Err(AggregateError::Conflict.into());
+            return Err(AggregateError::Conflict);
         }
-        tx.commit().await?;
+        tx.commit()
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         Ok(())
     }
 }

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -4,7 +4,7 @@ use kernel::event::WidgetEvent;
 use kernel::processor::CommandProcessor;
 use lib::Error;
 
-use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel, WidgetEventModels};
+use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel};
 use crate::persistence::ConnectionPool;
 
 pub struct WidgetRepository {
@@ -64,7 +64,7 @@ impl CommandProcessor for WidgetRepository {
         // 前回集約が保存された際に作成されたイベントを Event テーブルに個々の項目として永続化する
         let widget_id = widget_id.to_string();
         let aggregate_version = model.aggregate_version();
-        let WidgetEventModels(models) = model.try_into()?;
+        let models: Vec<WidgetEventModel> = model.try_into()?;
         let mut tx = self
             .pool
             .begin()

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -79,7 +79,10 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
     ) -> Result<String> {
         let aggregate = WidgetAggregate::default();
         let widget_id = aggregate.id().to_string();
-        let command = WidgetCommand::create_widget(widget_name, widget_description);
+        let command = WidgetCommand::CreateWidget {
+            widget_name,
+            widget_description,
+        };
         let command_state = aggregate
             .apply_command(command)
             .map_err(|e| self.handling_command_error(e))?;
@@ -99,7 +102,9 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
                 .get_widget_aggregate(widget_id.parse()?)
                 .await?
                 .ok_or(WidgetServiceError::AggregateNotFound)?;
-            let command = WidgetCommand::change_widget_name(widget_name.clone());
+            let command = WidgetCommand::ChangeWidgetName {
+                widget_name: widget_name.clone(),
+            };
             let command_state = aggregate
                 .apply_command(command)
                 .map_err(|e| self.handling_command_error(e))?;
@@ -129,7 +134,9 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
                 .get_widget_aggregate(widget_id.parse()?)
                 .await?
                 .ok_or(WidgetServiceError::AggregateNotFound)?;
-            let command = WidgetCommand::change_widget_description(widget_description.clone());
+            let command = WidgetCommand::ChangeWidgetDescription {
+                widget_description: widget_description.clone(),
+            };
             let command_state = aggregate
                 .apply_command(command)
                 .map_err(|e| self.handling_command_error(e))?;

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -2,12 +2,12 @@ use std::future::Future;
 
 use kernel::aggregate::WidgetAggregate;
 use kernel::command::WidgetCommand;
-use kernel::error::{AggregateError, CommandError};
+use kernel::error::{AggregateError, ApplyCommandError};
 use kernel::processor::CommandProcessor;
-use lib::{Error, Result};
+use lib::Error;
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Error, Debug)]
 pub enum WidgetServiceError {
     /// Aggregate が存在しないときのエラー
     #[error("Aggregate not found")]
@@ -18,6 +18,29 @@ pub enum WidgetServiceError {
     /// 要求された値が不正なときのエラー
     #[error("Invalid value")]
     InvalidValue,
+    #[error("error")]
+    Unknow(#[from] Error),
+}
+
+impl From<ApplyCommandError> for WidgetServiceError {
+    fn from(value: ApplyCommandError) -> Self {
+        match value {
+            ApplyCommandError::InvalidWidgetName | ApplyCommandError::InvalidWidgetDescription => {
+                WidgetServiceError::InvalidValue
+            }
+            ApplyCommandError::VersionOverflow => WidgetServiceError::Unknow(value.into()),
+        }
+    }
+}
+
+impl From<AggregateError> for WidgetServiceError {
+    fn from(value: AggregateError) -> Self {
+        match value {
+            AggregateError::Conflict => Self::AggregateConfilict,
+            AggregateError::NotFound => Self::AggregateNotFound,
+            AggregateError::Unknow(e) => Self::Unknow(e),
+        }
+    }
 }
 
 /// 部品 (Widget) のユースケース処理のインターフェイス
@@ -27,19 +50,19 @@ pub trait WidgetService {
         &self,
         widget_name: String,
         widget_description: String,
-    ) -> impl Future<Output = Result<String>> + Send;
+    ) -> impl Future<Output = Result<String, WidgetServiceError>> + Send;
     /// 部品の名前を変更する
     fn change_widget_name(
         &self,
         widget_id: String,
         widget_name: String,
-    ) -> impl Future<Output = Result<()>> + Send;
+    ) -> impl Future<Output = Result<(), WidgetServiceError>> + Send;
     /// 部品の説明を変更する
     fn change_widget_description(
         &self,
         widget_id: String,
         widget_description: String,
-    ) -> impl Future<Output = Result<()>> + Send;
+    ) -> impl Future<Output = Result<(), WidgetServiceError>> + Send;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -51,24 +74,6 @@ impl<C: CommandProcessor> WidgetServiceImpl<C> {
     pub fn new(command: C) -> Self {
         Self { command }
     }
-
-    fn handling_command_error(&self, err: Error) -> Error {
-        match err.downcast_ref::<CommandError>() {
-            Some(e) => match e {
-                CommandError::InvalidWidgetName | CommandError::InvalidWidgetDescription => {
-                    WidgetServiceError::InvalidValue.into()
-                }
-            },
-            None => err,
-        }
-    }
-
-    fn handling_aggregate_error(&self, err: Error) -> Result<()> {
-        match err.downcast_ref::<AggregateError>() {
-            Some(AggregateError::Conflict) => Ok(()),
-            _ => Err(err),
-        }
-    }
 }
 
 impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServiceImpl<C> {
@@ -76,44 +81,43 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         &self,
         widget_name: String,
         widget_description: String,
-    ) -> Result<String> {
+    ) -> Result<String, WidgetServiceError> {
         let aggregate = WidgetAggregate::default();
         let widget_id = aggregate.id().to_string();
         let command = WidgetCommand::CreateWidget {
             widget_name,
             widget_description,
         };
-        let command_state = aggregate
-            .apply_command(command)
-            .map_err(|e| self.handling_command_error(e))?;
+        let command_state = aggregate.apply_command(command)?;
         self.command.create_widget_aggregate(command_state).await?;
         Ok(widget_id)
     }
 
-    async fn change_widget_name(&self, widget_id: String, widget_name: String) -> Result<()> {
+    async fn change_widget_name(
+        &self,
+        widget_id: String,
+        widget_name: String,
+    ) -> Result<(), WidgetServiceError> {
         const MAX_RETRY_COUNT: u32 = 3;
         let mut retry_count = 0;
         loop {
-            if retry_count > MAX_RETRY_COUNT {
-                return Err(WidgetServiceError::AggregateConfilict.into());
-            }
             let aggregate = self
                 .command
                 .get_widget_aggregate(widget_id.parse()?)
-                .await?
-                .ok_or(WidgetServiceError::AggregateNotFound)?;
+                .await?;
             let command = WidgetCommand::ChangeWidgetName {
                 widget_name: widget_name.clone(),
             };
-            let command_state = aggregate
-                .apply_command(command)
-                .map_err(|e| self.handling_command_error(e))?;
-            let result = self.command.update_widget_aggregate(command_state).await;
-            if result.is_ok() {
-                break;
+            let command_state = aggregate.apply_command(command)?;
+            match self.command.update_widget_aggregate(command_state).await {
+                Ok(_) => break,
+                Err(e) => match e {
+                    AggregateError::Conflict if retry_count.le(&MAX_RETRY_COUNT) => {
+                        retry_count += 1
+                    }
+                    _ => return Err(e.into()),
+                },
             }
-            self.handling_aggregate_error(result.err().unwrap())?;
-            retry_count += 1;
         }
         Ok(())
     }
@@ -122,30 +126,30 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         &self,
         widget_id: String,
         widget_description: String,
-    ) -> Result<()> {
+    ) -> Result<(), WidgetServiceError> {
         const MAX_RETRY_COUNT: u32 = 3;
         let mut retry_count = 0;
         loop {
             if retry_count > MAX_RETRY_COUNT {
-                return Err(WidgetServiceError::AggregateConfilict.into());
+                return Err(WidgetServiceError::AggregateConfilict);
             }
             let aggregate = self
                 .command
                 .get_widget_aggregate(widget_id.parse()?)
-                .await?
-                .ok_or(WidgetServiceError::AggregateNotFound)?;
+                .await?;
             let command = WidgetCommand::ChangeWidgetDescription {
                 widget_description: widget_description.clone(),
             };
-            let command_state = aggregate
-                .apply_command(command)
-                .map_err(|e| self.handling_command_error(e))?;
-            let result = self.command.update_widget_aggregate(command_state).await;
-            if result.is_ok() {
-                break;
+            let command_state = aggregate.apply_command(command)?;
+            match self.command.update_widget_aggregate(command_state).await {
+                Ok(_) => break,
+                Err(e) => match e {
+                    AggregateError::Conflict if retry_count.le(&MAX_RETRY_COUNT) => {
+                        retry_count += 1
+                    }
+                    _ => return Err(e.into()),
+                },
             }
-            self.handling_aggregate_error(result.err().unwrap())?;
-            retry_count += 1;
         }
         Ok(())
     }

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -105,14 +105,14 @@ async fn change_widget_description<S: WidgetService>(
     }
 }
 
-fn handling_service_error(err: Error) -> impl IntoResponse {
-    match err.downcast_ref::<WidgetServiceError>() {
-        Some(e) => match e {
-            WidgetServiceError::AggregateNotFound => StatusCode::NOT_FOUND.into_response(),
-            WidgetServiceError::AggregateConfilict => StatusCode::CONFLICT.into_response(),
-            WidgetServiceError::InvalidValue => StatusCode::BAD_REQUEST.into_response(),
-        },
-        None => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+fn handling_service_error(err: WidgetServiceError) -> impl IntoResponse {
+    match err {
+        WidgetServiceError::AggregateNotFound => StatusCode::NOT_FOUND.into_response(),
+        WidgetServiceError::AggregateConfilict => StatusCode::CONFLICT.into_response(),
+        WidgetServiceError::InvalidValue => StatusCode::BAD_REQUEST.into_response(),
+        WidgetServiceError::Unknow(e) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
     }
 }
 

--- a/internal/kernel/src/command.rs
+++ b/internal/kernel/src/command.rs
@@ -1,40 +1,13 @@
-use crate::event::WidgetEvent;
-use crate::Id;
-
 /// 部品 (Widget) に対するコマンド
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum WidgetCommand {
     /// 部品を新しく作成する
-    CreateWidget(WidgetEvent),
+    CreateWidget {
+        widget_name: String,
+        widget_description: String,
+    },
     /// 部品の名前を変更する
-    ChangeWidgetName(WidgetEvent),
+    ChangeWidgetName { widget_name: String },
     /// 部品の説明を変更する
-    ChangeWidgetDescription(WidgetEvent),
-}
-
-impl WidgetCommand {
-    /// 部品を新しく作成する
-    pub fn create_widget(widget_name: String, widget_description: String) -> Self {
-        Self::CreateWidget(WidgetEvent::WidgetCreated {
-            id: Id::generate(),
-            widget_name,
-            widget_description,
-        })
-    }
-
-    /// 部品の名前を変更する
-    pub fn change_widget_name(widget_name: String) -> Self {
-        Self::ChangeWidgetName(WidgetEvent::WidgetNameChanged {
-            id: Id::generate(),
-            widget_name,
-        })
-    }
-
-    /// 部品の説明を変更する
-    pub fn change_widget_description(widget_description: String) -> Self {
-        Self::ChangeWidgetDescription(WidgetEvent::WidgetDescriptionChanged {
-            id: Id::generate(),
-            widget_description,
-        })
-    }
+    ChangeWidgetDescription { widget_description: String },
 }

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -1,19 +1,37 @@
+use lib::Error;
 use thiserror::Error;
 
 /// コマンドの実行に失敗したことを表す
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CommandError {
+pub enum ApplyCommandError {
     /// イベントに含まれる部品の名前が不正なフォーマットのときのエラー
     #[error("Invalid name for the widget")]
     InvalidWidgetName,
     /// イベントに含まれる部品の説明が不正なフォーマットのときのエラー
     #[error("Invalid description for the widget")]
     InvalidWidgetDescription,
+    /// イベントに含まれる部品の説明が不正なフォーマットのときのエラー
+    #[error("Cannot update Aggregate version")]
+    VersionOverflow,
 }
 
+/// イベントから復元時のエラー
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LoadEventError {
+    /// Aggregate 復元時に version が実体と一致しないときのエラー
+    #[error("Not match aggregate version")]
+    NotMatchVersion,
+}
+
+#[derive(Error, Debug)]
 pub enum AggregateError {
     /// Aggregate が既に更新さているときのエラー
     #[error("Aggregate is already updated")]
     Conflict,
+    /// Aggregate が存在しないときのエラー
+    #[error("Aggregate not found")]
+    NotFound,
+    /// その他のエラー
+    #[error(transparent)]
+    Unknow(#[from] Error),
 }

--- a/internal/kernel/src/event.rs
+++ b/internal/kernel/src/event.rs
@@ -1,3 +1,4 @@
+use crate::command::WidgetCommand;
 use crate::Id;
 
 /// 部品 (Widget) に発生するイベント
@@ -26,4 +27,29 @@ pub enum WidgetEvent {
         /// 部品の名前
         widget_description: String,
     },
+}
+
+impl From<WidgetCommand> for Vec<WidgetEvent> {
+    fn from(value: WidgetCommand) -> Self {
+        let id = Id::generate();
+        match value {
+            WidgetCommand::CreateWidget {
+                widget_name,
+                widget_description,
+            } => vec![WidgetEvent::WidgetCreated {
+                id,
+                widget_name,
+                widget_description,
+            }],
+            WidgetCommand::ChangeWidgetName { widget_name } => {
+                vec![WidgetEvent::WidgetNameChanged { id, widget_name }]
+            }
+            WidgetCommand::ChangeWidgetDescription { widget_description } => {
+                vec![WidgetEvent::WidgetDescriptionChanged {
+                    id,
+                    widget_description,
+                }]
+            }
+        }
+    }
 }

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -1,6 +1,5 @@
-use lib::Result;
-
 use crate::aggregate::{WidgetAggregate, WidgetCommandState};
+use crate::error::AggregateError;
 use crate::Id;
 
 /// 集約を永続化する処理のインターフェイス
@@ -9,15 +8,15 @@ pub trait CommandProcessor {
     fn create_widget_aggregate(
         &self,
         command_state: WidgetCommandState,
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), AggregateError>> + Send;
     /// 部品の集約を取得する
     fn get_widget_aggregate(
         &self,
         widget_id: Id<WidgetAggregate>,
-    ) -> impl std::future::Future<Output = Result<Option<WidgetAggregate>>> + Send;
+    ) -> impl std::future::Future<Output = Result<WidgetAggregate, AggregateError>> + Send;
     /// 部品の集約を更新する
     fn update_widget_aggregate(
         &self,
         command_state: WidgetCommandState,
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), AggregateError>> + Send;
 }

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -1,5 +1,4 @@
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-pub type Result<T> = core::result::Result<T, Error>;
 
 pub fn database_url() -> String {
     format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use adapter::persistence::connect;
 use adapter::repository::WidgetRepository;
 use app::WidgetServiceImpl;
 use driver::Server;
-use lib::{database_url, Result};
+use lib::{database_url, Error};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Error> {
     let pool = connect(&database_url()).await?;
     let repository = WidgetRepository::new(pool);
     let service = WidgetServiceImpl::new(repository);


### PR DESCRIPTION
## Overview

- change: ApplyCommand/LoadEvents の処理が冗長になっていたのでリファクタリングした
  - LoadEvents を Aggregate 内の関数から呼び出せるようにする
  - Command に Event のリストを持たせないで、Command から Event に変換するようにした
  - Event payload のフォーマットチェックを1関数で処理する
- change: app / kernel / adapter が返すエラーに `Box<dyn std::error::Error + Send + Sync + 'static>` を指定していたせいでエラーの情報が欠落していたのでカスタムエラーを定義した (#8)
