### PR TITLE
add: Testcontainers で Database を利用したテストを追加する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,9 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum_macros",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
  "ulid",
 ]
 
@@ -201,6 +204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+dependencies = [
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +299,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -424,6 +472,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +531,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,8 +559,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -690,6 +766,12 @@ dependencies = [
  "socket2",
  "tokio",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1226,6 +1308,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum_macros"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1701,32 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
+dependencies = [
+ "bollard-stubs",
+ "futures",
+ "hex",
+ "hmac",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5c0d66f296de264c0593f42ea2ef2ad3ff9a62bc946a5d4e8d21be1317c505"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]

--- a/internal/adapter/Cargo.toml
+++ b/internal/adapter/Cargo.toml
@@ -14,4 +14,7 @@ sqlx = { version = "0.7.3", features = ["runtime-tokio", "mysql", "json"] }
 strum_macros = "0.26.1"
 
 [dev-dependencies]
+testcontainers = "0.15.0"
+testcontainers-modules = { version = "0.3.2", features = ["mysql"] }
+tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 ulid = "1.1.2"

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -161,7 +161,7 @@ mod tests {
 
     use kernel::aggregate::{WidgetAggregate, WidgetCommandState};
     use kernel::command::WidgetCommand;
-    use kernel::error::AggregateError;
+    use kernel::error::{AggregateError, LoadEventError};
     use kernel::processor::CommandProcessor;
     use kernel::Id;
     use lib::Error;
@@ -763,6 +763,8 @@ mod tests {
                 assert: Box::new(move |name, result, _| {
                     Box::new(async move {
                         assert!(result.is_err(), "{name}");
+                        let e = result.err().unwrap();
+                        assert_eq!(e.to_string(), LoadEventError::EventsIsEmpty.to_string(), "{name}");
                         Ok(())
                     })
                 }),

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -7,6 +7,11 @@ use lib::Error;
 use crate::model::{WidgetAggregateModel, WidgetEventMapper, WidgetEventModel};
 use crate::persistence::ConnectionPool;
 
+const QUERY_INSERT_AGGREGATE: &str =
+    "INSERT INTO aggregate (widget_id, last_events, aggregate_version) VALUES (?, ?, ?)";
+const QUERY_INSERT_EVENT: &str =
+    "INSERT INTO event (event_id, widget_id, event_name, payload) VALUES (?, ?, ?, ?)";
+
 pub struct WidgetRepository {
     pool: ConnectionPool,
 }
@@ -28,15 +33,13 @@ impl CommandProcessor for WidgetRepository {
             .begin()
             .await
             .map_err(|e| AggregateError::Unknow(e.into()))?;
-        sqlx::query(
-            "INSERT INTO aggregate (widget_id, last_events, aggregate_version) VALUES (?, ?, ?)",
-        )
-        .bind(model.widget_id())
-        .bind(model.last_events())
-        .bind(model.aggregate_version())
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| AggregateError::Unknow(e.into()))?;
+        sqlx::query(QUERY_INSERT_AGGREGATE)
+            .bind(model.widget_id())
+            .bind(model.last_events())
+            .bind(model.aggregate_version())
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AggregateError::Unknow(e.into()))?;
         tx.commit()
             .await
             .map_err(|e| AggregateError::Unknow(e.into()))?;
@@ -71,15 +74,13 @@ impl CommandProcessor for WidgetRepository {
             .await
             .map_err(|e| AggregateError::Unknow(e.into()))?;
         for model in models {
-            let result = sqlx::query(
-                "INSERT INTO event (event_id, widget_id, event_name, payload) VALUES (?, ?, ?, ?)",
-            )
-            .bind(model.event_id())
-            .bind(&widget_id)
-            .bind(model.event_name())
-            .bind(model.payload())
-            .execute(&mut *tx)
-            .await;
+            let result = sqlx::query(QUERY_INSERT_EVENT)
+                .bind(model.event_id())
+                .bind(&widget_id)
+                .bind(model.event_name())
+                .bind(model.payload())
+                .execute(&mut *tx)
+                .await;
             if let Err(e) = result {
                 match e.as_database_error() {
                     // NOTE: イベントが既に存在してもイベントは変更不可能なのでエラーを無視する
@@ -171,6 +172,8 @@ mod tests {
     use crate::persistence::{connect, ConnectionPool};
     use crate::repository::WidgetRepository;
 
+    use super::{QUERY_INSERT_AGGREGATE, QUERY_INSERT_EVENT};
+
     type AsyncAssertFn<'a, T> = Box<
         fn(
             name: &'a str,
@@ -181,6 +184,114 @@ mod tests {
 
     const WIDGET_NAME: &str = "部品名";
     const WIDGET_DESCRIPTION: &str = "部品の説明";
+
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    enum DateTime {
+        /// 2023-01-01T00:00:00Z
+        DT2023_01_01_00_00_00_00,
+        /// 2023-01-01T00:00:01Z
+        DT2023_01_01_00_00_00_01,
+        /// 2023-01-01T00:00:02Z
+        DT2023_01_01_00_00_00_02,
+        /// 2023-01-01T00:01:00Z
+        DT2023_01_01_00_00_01_00,
+        /// 2023-01-01T01:00:00Z
+        DT2023_01_01_00_01_00_00,
+        /// 2023-01-01T01:00:00Z
+        DT2023_01_01_01_00_00_00,
+        /// 2023-01-02T00:00:00Z
+        DT2023_01_02_00_00_00_00,
+        /// 2023-02-01T00:00:00Z
+        DT2023_02_01_00_00_00_00,
+        /// 2024-01-01T00:00:00Z
+        DT2024_01_01_00_00_00_00,
+    }
+
+    impl DateTime {
+        fn id(self) -> String {
+            match self {
+                DateTime::DT2023_01_01_00_00_00_00 => "01GNNA1J00PQ9J874NBWERBM3Z",
+                DateTime::DT2023_01_01_00_00_00_01 => "01GNNA1J015CFH0CA590B4K9K6",
+                DateTime::DT2023_01_01_00_00_00_02 => "01GNNA1J02N9H1YCMRA2R9Q562",
+                DateTime::DT2023_01_01_00_00_01_00 => "01GNNA1JZ86A6F1G8HV7NYHDCN",
+                DateTime::DT2023_01_01_00_01_00_00 => "01GNNA3CK0B63HH8HBYQVRJ5Y8",
+                DateTime::DT2023_01_01_01_00_00_00 => "01GNNDFDM0WV3PR6RM8TEA7MZ5",
+                DateTime::DT2023_01_02_00_00_00_00 => "01GNQWE9003DQHKPAAHCDCVTJZ",
+                DateTime::DT2023_02_01_00_00_00_00 => "01GR57SPM0XBGEG4A13ZBW02G2",
+                DateTime::DT2024_01_01_00_00_00_00 => "01HK153X00D14NM09FKYEJ7MPY",
+            }
+            .to_string()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Fixture {
+        Aggregate {
+            widget_id: String,
+            last_events: serde_json::Value,
+            aggregate_version: u64,
+        },
+        Event {
+            event_id: String,
+            widget_id: String,
+            event_name: String,
+            payload: serde_json::Value,
+        },
+    }
+
+    impl Fixture {
+        fn aggregate(
+            widget_id: String,
+            last_events: serde_json::Value,
+            aggregate_version: u64,
+        ) -> Self {
+            Self::Aggregate {
+                widget_id,
+                last_events,
+                aggregate_version,
+            }
+        }
+
+        fn event(
+            event_id: String,
+            widget_id: String,
+            event_name: &str,
+            payload: serde_json::Value,
+        ) -> Self {
+            Self::Event {
+                event_id,
+                widget_id,
+                event_name: event_name.to_string(),
+                payload,
+            }
+        }
+
+        async fn execute(self, pool: &ConnectionPool) -> Result<(), Error> {
+            let query = match self {
+                Fixture::Aggregate {
+                    widget_id,
+                    last_events,
+                    aggregate_version,
+                } => sqlx::query(QUERY_INSERT_AGGREGATE)
+                    .bind(widget_id)
+                    .bind(last_events)
+                    .bind(aggregate_version),
+                Fixture::Event {
+                    event_id,
+                    widget_id,
+                    event_name,
+                    payload,
+                } => sqlx::query(QUERY_INSERT_EVENT)
+                    .bind(event_id)
+                    .bind(widget_id)
+                    .bind(event_name)
+                    .bind(payload),
+            };
+            query.execute(pool).await?;
+            Ok(())
+        }
+    }
 
     /// 集約の作成を永続化するテスト
     #[tokio::test]
@@ -265,6 +376,410 @@ mod tests {
         Ok(())
     }
 
+    /// 集約を復元するテスト
+    #[tokio::test]
+    async fn test_get_aggregate() -> Result<(), Error> {
+        let docker = Cli::default();
+        let container = docker.run(Mysql::default());
+        let pool = connect(&format!(
+            "mysql://root@127.0.0.1:{}/mysql",
+            container.get_host_port_ipv4(3306)
+        ))
+        .await?;
+        sqlx::query(include_str!(
+            "../../../migrations/20240210132634_create_aggregate.sql"
+        ))
+        .execute(&pool)
+        .await?;
+        sqlx::query(include_str!(
+            "../../../migrations/20240210132646_create_event.sql"
+        ))
+        .execute(&pool)
+        .await?;
+
+        struct TestCase<'a> {
+            name: &'a str,
+            widget_id: Id<WidgetAggregate>,
+            fixtures: Vec<Fixture>,
+            assert: AsyncAssertFn<'a, Result<WidgetAggregate, AggregateError>>,
+        }
+        let tests = vec![
+            TestCase {
+                name: "Aggregate テーブルに直近のイベントが集約作成イベントかつイベントが永続化前の場合、Aggregate テーブルから集約を復元できる",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![Fixture::aggregate(
+                    DateTime::DT2023_01_01_00_00_00_00.id(),
+                    serde_json::json!([{
+                        "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "event_name": "WidgetCreated",
+                        "payload": {
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        },
+                    }]),
+                    0,
+                )],
+                assert: Box::new(move |name, result, _| {
+                    Box::new(async move {
+                        assert!(result.is_ok(), "{name}");
+                        let aggregate = result.unwrap();
+                        assert_eq!(aggregate.name(), WIDGET_NAME, "{name}");
+                        assert_eq!(aggregate.description(), WIDGET_DESCRIPTION, "{name}");
+                        assert_eq!(aggregate.version(), 0, "{name}");
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Aggregate テーブルに直近のイベントが集約作成イベントかつイベントが永続化前の場合、Aggregate テーブルは変更されない",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![Fixture::aggregate(
+                    DateTime::DT2023_01_01_00_00_00_00.id(),
+                    serde_json::json!([{
+                        "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "event_name": "WidgetCreated",
+                        "payload": {
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        },
+                    }]),
+                    0,
+                )],
+                assert: Box::new(move |name, _, pool| {
+                    Box::new(async move {
+                        let models: Vec<WidgetAggregateModel> =
+                            sqlx::query_as("SELECT * FROM aggregate")
+                                .fetch_all(&pool)
+                                .await?;
+                        assert_eq!(models.len(), 1, "{name}");
+                        let model = models.first().unwrap();
+                        assert_eq!(model.aggregate_version(), 0, "{name}");
+                        assert_eq!(
+                            model.last_events(),
+                            &serde_json::json!([{
+                                "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
+                                "event_name": "WidgetCreated",
+                                "payload": {
+                                    "version": "V1",
+                                    "widget_name": WIDGET_NAME,
+                                    "widget_description": WIDGET_DESCRIPTION,
+                                },
+                            }]),
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Aggregate テーブルに直近のイベントが集約作成イベントかつイベントが永続化前の場合、Event テーブルに集約作成イベントが永続化される",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![Fixture::aggregate(
+                    DateTime::DT2023_01_01_00_00_00_00.id(),
+                    serde_json::json!([{
+                        "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "event_name": "WidgetCreated",
+                        "payload": {
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        },
+                    }]),
+                    0,
+                )],
+                assert: Box::new(move |name, _, pool| {
+                    Box::new(async move {
+                        let models: Vec<WidgetEventModel> = sqlx::query_as("SELECT * FROM event")
+                            .fetch_all(&pool)
+                            .await?;
+                        assert_eq!(models.len(), 1, "{name}");
+                        let model = models.first().unwrap();
+                        assert_eq!(
+                            model.event_id(),
+                            DateTime::DT2023_01_01_00_00_00_00.id(),
+                            "{name}"
+                        );
+                        assert_eq!(model.event_name(), "WidgetCreated", "{name}");
+                        assert_eq!(
+                            model.payload(),
+                            &serde_json::json!({
+                                "version": "V1",
+                                "widget_name": WIDGET_NAME,
+                                "widget_description": WIDGET_DESCRIPTION
+                            }),
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Aggregate テーブルの直近のイベントが永続化後の場合、エラーなく集約を取得でき、Event テーブルも変更されない",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![
+                    Fixture::aggregate(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        serde_json::json!([{
+                            "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
+                            "event_name": "WidgetCreated",
+                            "payload": {
+                                "version": "V1",
+                                "widget_name": WIDGET_NAME,
+                                "widget_description": WIDGET_DESCRIPTION,
+                            },
+                        }]),
+                        0,
+                    ),
+                    Fixture::event(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "WidgetCreated",
+                        serde_json::json!({
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        }),
+                    ),
+                ],
+                assert: Box::new(move |name, result, pool| {
+                    Box::new(async move {
+                        assert!(result.is_ok(), "{name}");
+                        let aggregate = result.unwrap();
+                        assert_eq!(aggregate.name(), WIDGET_NAME, "{name}");
+                        assert_eq!(aggregate.description(), WIDGET_DESCRIPTION, "{name}");
+                        assert_eq!(aggregate.version(), 0, "{name}");
+
+                        let models: Vec<WidgetEventModel> = sqlx::query_as("SELECT * FROM event")
+                            .fetch_all(&pool)
+                            .await?;
+                        assert_eq!(models.len(), 1, "{name}");
+                        let model = models.first().unwrap();
+                        assert_eq!(
+                            model.event_id(),
+                            DateTime::DT2023_01_01_00_00_00_00.id(),
+                            "{name}"
+                        );
+                        assert_eq!(model.event_name(), "WidgetCreated", "{name}");
+                        assert_eq!(
+                            model.payload(),
+                            &serde_json::json!({
+                                "version": "V1",
+                                "widget_name": WIDGET_NAME,
+                                "widget_description": WIDGET_DESCRIPTION
+                            }),
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "複数のイベントがある場合、全てのイベントから集約を復元する",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![
+                    Fixture::aggregate(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        serde_json::json!([{
+                            "event_id": DateTime::DT2023_01_01_00_00_00_02.id(),
+                            "event_name": "WidgetDescriptionChanged",
+                            "payload": {
+                                "version": "V1",
+                                "widget_description": "部品の説明v2",
+                            },
+                        }]),
+                        2,
+                    ),
+                    Fixture::event(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "WidgetCreated",
+                        serde_json::json!({
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        }),
+                    ),
+                    Fixture::event(
+                        DateTime::DT2023_01_01_00_00_00_01.id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "WidgetNameChanged",
+                        serde_json::json!({
+                            "version": "V1",
+                            "widget_name": "部品名v2",
+                        }),
+                    ),
+                ],
+                assert: Box::new(move |name, result, pool| {
+                    Box::new(async move {
+                        assert!(result.is_ok(), "{name}");
+                        let aggregate = result.unwrap();
+                        assert_eq!(aggregate.name(), "部品名v2", "{name}");
+                        assert_eq!(aggregate.description(), "部品の説明v2", "{name}");
+                        assert_eq!(aggregate.version(), 2, "{name}");
+
+                        let models: Vec<WidgetAggregateModel> =
+                            sqlx::query_as("SELECT * FROM aggregate")
+                                .fetch_all(&pool)
+                                .await?;
+                        assert_eq!(models.len(), 1, "{name}");
+                        let model = models.last().unwrap();
+                        assert_eq!(model.aggregate_version(), 2, "{name}");
+                        assert_eq!(
+                            model.last_events(),
+                            &serde_json::json!([{
+                                "event_id": DateTime::DT2023_01_01_00_00_00_02.id(),
+                                "event_name": "WidgetDescriptionChanged",
+                                "payload": {
+                                    "version": "V1",
+                                    "widget_description": "部品の説明v2",
+                                },
+                            }]),
+                            "{name}"
+                        );
+
+                        let models: Vec<WidgetEventModel> =
+                            sqlx::query_as("SELECT * FROM event ORDER BY event_id ASC")
+                                .fetch_all(&pool)
+                                .await?;
+                        assert_eq!(models.len(), 3, "{name}");
+                        let model = models.last().unwrap();
+                        assert_eq!(model.event_name(), "WidgetDescriptionChanged", "{name}");
+                        assert_eq!(
+                            model.payload(),
+                            &serde_json::json!({
+                                "version": "V1",
+                                "widget_description": "部品の説明v2"
+                            }),
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "同一のイベントが複数ある場合、イベントの発生順に集約を復元する",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![
+                    Fixture::aggregate(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        serde_json::json!([{
+                            "event_id": DateTime::DT2023_01_01_00_00_00_02.id(),
+                            "event_name": "WidgetNameChanged",
+                            "payload": {
+                                "version": "V1",
+                                "widget_name": "部品名v3"
+                            },
+                        }]),
+                        2,
+                    ),
+                    Fixture::event(
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "WidgetCreated",
+                        serde_json::json!({
+                            "version": "V1",
+                            "widget_name": WIDGET_NAME,
+                            "widget_description": WIDGET_DESCRIPTION,
+                        }),
+                    ),
+                    Fixture::event(
+                        DateTime::DT2023_01_01_00_00_00_01.id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "WidgetNameChanged",
+                        serde_json::json!({
+                            "version": "V1",
+                            "widget_name": "部品名v2",
+                        }),
+                    ),
+                ],
+                assert: Box::new(move |name, result, pool| {
+                    Box::new(async move {
+                        assert!(result.is_ok(), "{name}");
+                        let aggregate = result.unwrap();
+                        assert_eq!(aggregate.name(), "部品名v3", "{name}");
+                        assert_eq!(aggregate.description(), WIDGET_DESCRIPTION, "{name}");
+                        assert_eq!(aggregate.version(), 2, "{name}");
+
+                        let models: Vec<WidgetAggregateModel> =
+                            sqlx::query_as("SELECT * FROM aggregate")
+                                .fetch_all(&pool)
+                                .await?;
+                        assert_eq!(models.len(), 1, "{name}");
+                        let model = models.first().unwrap();
+                        assert_eq!(model.aggregate_version(), 2, "{name}");
+                        assert_eq!(
+                            model.last_events(),
+                            &serde_json::json!([{
+                                "event_id": DateTime::DT2023_01_01_00_00_00_02.id(),
+                                "event_name": "WidgetNameChanged",
+                                "payload": {
+                                    "version": "V1",
+                                    "widget_name": "部品名v3"
+                                },
+                            }]),
+                            "{name}"
+                        );
+
+                        let models: Vec<WidgetEventModel> =
+                            sqlx::query_as("SELECT * FROM event ORDER BY event_id ASC")
+                                .fetch_all(&pool)
+                                .await?;
+                        assert_eq!(models.len(), 3, "{name}");
+                        let model = models.last().unwrap();
+                        assert_eq!(model.event_name(), "WidgetNameChanged", "{name}");
+                        assert_eq!(
+                            model.payload(),
+                            &serde_json::json!({
+                                "version": "V1",
+                                "widget_name": "部品名v3"
+                            }),
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "集約が存在しない場合は、AggregateError::NotFoud が返る",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: Vec::new(),
+                assert: Box::new(move |name, result, _| {
+                    Box::new(async move {
+                        assert!(matches!(result, Err(AggregateError::NotFound)), "{name}");
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Aggregate テーブルの last_events が不正な場合、エラーが起きる",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse()?,
+                fixtures: vec![Fixture::aggregate(
+                    DateTime::DT2023_01_01_00_00_00_00.id(),
+                    serde_json::json!([]),
+                    0,
+                )],
+                assert: Box::new(move |name, result, _| {
+                    Box::new(async move {
+                        assert!(result.is_err(), "{name}");
+                        Ok(())
+                    })
+                }),
+            },
+        ];
+        let repository = WidgetRepository::new(pool.clone());
+        for test in tests {
+            sqlx::query("TRUNCATE TABLE aggregate")
+                .execute(&pool)
+                .await?;
+            sqlx::query("TRUNCATE TABLE event").execute(&pool).await?;
+            for fixture in test.fixtures {
+                fixture.execute(&pool).await?;
+            }
+            let result = repository.get_widget_aggregate(test.widget_id).await;
+            Pin::from((test.assert)(test.name, result, pool.clone())).await?;
+        }
         Ok(())
     }
 }

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -56,6 +56,10 @@ impl WidgetAggregate {
         events: Vec<WidgetEvent>,
         version: u64,
     ) -> Result<Self, LoadEventError> {
+        if events.is_empty() {
+            return Err(LoadEventError::EventsIsEmpty);
+        }
+
         for event in events {
             match event {
                 WidgetEvent::WidgetCreated {

--- a/internal/kernel/src/error.rs
+++ b/internal/kernel/src/error.rs
@@ -21,6 +21,9 @@ pub enum ApplyCommandError {
 /// イベントから復元時のエラー
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LoadEventError {
+    /// イベントが存在しないときのエラー
+    #[error("events is empty")]
+    EventsIsEmpty,
     /// Aggregate 復元時に version が実体と一致しないときのエラー
     #[error("Not match aggregate version")]
     NotMatchVersion,

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+WIDGET_ID=$(
+  curl -s http://localhost:8080/widgets \
+    -H "Content-Type: application/json" \
+    -d '
+      {
+        "widget_name": "widget name 1",
+        "widget_description": "widget description 1"
+      }' \
+    | jq -r '.widget_id'
+)
+curl -v "http://localhost:8080/widgets/${WIDGET_ID}/name" \
+  -H "Content-Type: application/json" \
+  -d '{ "widget_name": "widget name 2"}'
+curl -v "http://localhost:8080/widgets/${WIDGET_ID}/description" \
+  -H "Content-Type: application/json" \
+  -d '{ "widget_description": "widget description 2"}'


### PR DESCRIPTION
## Overview

[testcontainers](https://testcontainers.com/) で MySQL のコンテナを立ち上げて、Repository で集約の作成/取得/更新をしたときのテストを追加する

## Features

- 集約の作成を永続化するテストを追加する
- 集約を取得するテストを追加する
- 集約を更新するテストを追加する
- 時系列順にイベントを取得するテストを追加する

## Fixes

- イベントから集約を復元時にイベントが存在しない場合にエラーを返す
