### PR TITLE
add: mockall で各層のモックを利用したテストを追加する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
 name = "app"
 version = "0.1.0"
 dependencies = [
@@ -366,6 +372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "driver"
 version = "0.1.0"
 dependencies = [
@@ -470,6 +482,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -822,6 +840,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "lib",
+ "mockall",
  "thiserror",
  "ulid",
 ]
@@ -936,6 +955,33 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1139,6 +1185,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1702,6 +1774,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "testcontainers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "app",
  "axum",
  "lib",
+ "mockall",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.1.0"
 dependencies = [
  "kernel",
  "lib",
+ "mockall",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "kernel",
  "lib",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/internal/adapter/Cargo.toml
+++ b/internal/adapter/Cargo.toml
@@ -14,6 +14,7 @@ sqlx = { version = "0.7.3", features = ["runtime-tokio", "mysql", "json"] }
 strum_macros = "0.26.1"
 
 [dev-dependencies]
+lib = { path = "../lib", features = ["test"] }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.3.2", features = ["mysql"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/internal/adapter/src/model.rs
+++ b/internal/adapter/src/model.rs
@@ -234,7 +234,7 @@ mod tests {
 
     use kernel::aggregate::WidgetAggregate;
     use kernel::event::WidgetEvent;
-    use lib::Error;
+    use lib::{DateTime, Error};
     use ulid::Ulid;
 
     use crate::model::{
@@ -246,7 +246,6 @@ mod tests {
 
     const WIDGET_NAME: &str = "部品名";
     const WIDGET_DESCRIPTION: &str = "部品説明";
-    const EVENT_ID: &str = "01HPS5PP8444SAZ4XPCB407D0R";
 
     /// CommandState から Aggregate テーブルのモデルに変換するテスト
     #[test]
@@ -275,7 +274,7 @@ mod tests {
                 aggregate_model: WidgetAggregateModel {
                     widget_id: String::new(),
                     last_events: serde_json::to_value(vec![WidgetEventMapper::WidgetCreated {
-                        event_id: EVENT_ID.to_string(),
+                        event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                         payload: WidgetCreatedPayload::V1 {
                             widget_name: WIDGET_NAME.to_string(),
                             widget_description: WIDGET_DESCRIPTION.to_string(),
@@ -311,7 +310,7 @@ mod tests {
                 aggregate_model: WidgetAggregateModel {
                     widget_id: String::new(),
                     last_events: serde_json::to_value(vec![WidgetEventMapper::WidgetNameChanged {
-                        event_id: EVENT_ID.to_string(),
+                        event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                         payload: WidgetNameChangedPayload::V1 {
                             widget_name: WIDGET_NAME.to_string(),
                         },
@@ -344,7 +343,7 @@ mod tests {
                     widget_id: String::new(),
                     last_events: serde_json::to_value(vec![
                         WidgetEventMapper::WidgetDescriptionChanged {
-                            event_id: EVENT_ID.to_string(),
+                            event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                             payload: WidgetDescriptionChangedPayload::V1 {
                                 widget_description: WIDGET_DESCRIPTION.to_string(),
                             },
@@ -392,7 +391,7 @@ mod tests {
             TestCase {
                 name: "V1 の部品作成イベントの Event テーブルのモデルから変換する",
                 event_model: WidgetEventModel {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     event_name: "WidgetCreated".to_string(),
                     payload: serde_json::to_value(WidgetCreatedPayload::V1 {
                         widget_name: WIDGET_NAME.to_string(),
@@ -407,7 +406,11 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetCreated { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(
+                        mapper.event_id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "{name}"
+                    );
                     assert_eq!(mapper.event_name(), "WidgetCreated", "{name}");
                     assert_eq!(
                         mapper.to_payload_json_value().unwrap(),
@@ -423,7 +426,7 @@ mod tests {
             TestCase {
                 name: "V1 の部品名変更イベントの Event テーブルのモデルから変換する",
                 event_model: WidgetEventModel {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     event_name: "WidgetNameChanged".to_string(),
                     payload: serde_json::to_value(WidgetNameChangedPayload::V1 {
                         widget_name: WIDGET_NAME.to_string(),
@@ -437,7 +440,11 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetNameChanged { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(
+                        mapper.event_id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "{name}"
+                    );
                     assert_eq!(mapper.event_name(), "WidgetNameChanged", "{name}");
                     assert_eq!(
                         mapper.to_payload_json_value().unwrap(),
@@ -449,7 +456,7 @@ mod tests {
             TestCase {
                 name: "V1 の部品の説明変更イベントの Event テーブルのモデルから変換する",
                 event_model: WidgetEventModel {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     event_name: "WidgetDescriptionChanged".to_string(),
                     payload: serde_json::to_value(WidgetDescriptionChangedPayload::V1 {
                         widget_description: WIDGET_DESCRIPTION.to_string(),
@@ -463,7 +470,11 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetDescriptionChanged { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(
+                        mapper.event_id(),
+                        DateTime::DT2023_01_01_00_00_00_00.id(),
+                        "{name}"
+                    );
                     assert_eq!(mapper.event_name(), "WidgetDescriptionChanged", "{name}");
                     assert_eq!(
                         mapper.to_payload_json_value().unwrap(),
@@ -493,7 +504,7 @@ mod tests {
             TestCase {
                 name: "部品作成イベントの場合、ペイロードが V1 の部品作成マッパーに変換される",
                 event: WidgetEvent::WidgetCreated {
-                    id: EVENT_ID.parse().unwrap(),
+                    id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
                     widget_name: WIDGET_NAME.to_string(),
                     widget_description: WIDGET_DESCRIPTION.to_string(),
                 },
@@ -502,7 +513,7 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetCreated { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(mapper.event_id(), DateTime::DT2023_01_01_00_00_00_00.id(), "{name}");
                     assert_eq!(mapper.event_name(), "WidgetCreated", "{name}");
                     assert!(
                         matches!(
@@ -517,7 +528,7 @@ mod tests {
             TestCase {
                 name: "部品名変更イベントの場合、ペイロードが V1 の部品名変更マッパーに変換される",
                 event: WidgetEvent::WidgetNameChanged {
-                    id: EVENT_ID.parse().unwrap(),
+                    id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
                     widget_name: WIDGET_NAME.to_string(),
                 },
                 assert: |name: _, mapper: _| {
@@ -525,7 +536,7 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetNameChanged { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(mapper.event_id(), DateTime::DT2023_01_01_00_00_00_00.id(), "{name}");
                     assert_eq!(mapper.event_name(), "WidgetNameChanged", "{name}");
                     assert!(
                         matches!(
@@ -541,7 +552,7 @@ mod tests {
                 name:
                     "部品の説明変更イベントの場合、ペイロードが V1 の部品の説明変更マッパーに変換される",
                 event: WidgetEvent::WidgetDescriptionChanged {
-                    id: EVENT_ID.parse().unwrap(),
+                    id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
                     widget_description: WIDGET_DESCRIPTION.to_string(),
                 },
                 assert: |name: _, mapper: _| {
@@ -549,7 +560,7 @@ mod tests {
                         matches!(mapper, WidgetEventMapper::WidgetDescriptionChanged { .. }),
                         "{name}"
                     );
-                    assert_eq!(mapper.event_id(), EVENT_ID, "{name}");
+                    assert_eq!(mapper.event_id(), DateTime::DT2023_01_01_00_00_00_00.id(), "{name}");
                     assert_eq!(mapper.event_name(), "WidgetDescriptionChanged", "{name}");
                     assert!(
                         matches!(
@@ -579,7 +590,7 @@ mod tests {
             TestCase {
                 name: "部品作成イベントのマッパーの場合、V1 の部品作成イベントのペイロードを持つ JSON に変換される",
                 mapper: WidgetEventMapper::WidgetCreated {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     payload: WidgetCreatedPayload::V1 {
                         widget_name: WIDGET_NAME.to_string(),
                         widget_description: WIDGET_DESCRIPTION.to_string(),
@@ -591,7 +602,7 @@ mod tests {
                     assert_eq!(
                         json,
                         serde_json::json!({
-                            "event_id": EVENT_ID,
+                            "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
                             "event_name": "WidgetCreated",
                             "payload": serde_json::json!({
                                 "version": "V1",
@@ -606,7 +617,7 @@ mod tests {
             TestCase {
                 name: "部品名変更イベントのマッパーの場合、V1 の部品名変更イベントのペイロードを持つ JSON に変換される",
                 mapper: WidgetEventMapper::WidgetNameChanged {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     payload: WidgetNameChangedPayload::V1 {
                         widget_name: WIDGET_NAME.to_string(),
                     },
@@ -617,7 +628,7 @@ mod tests {
                     assert_eq!(
                         json,
                         serde_json::json!({
-                            "event_id": EVENT_ID,
+                            "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
                             "event_name": "WidgetNameChanged",
                             "payload": serde_json::json!({
                                 "version": "V1",
@@ -631,7 +642,7 @@ mod tests {
             TestCase {
                 name: "部品の説明変更イベントのマッパーの場合、V1 の部品の説明変更イベントのペイロードを持つ JSON に変換される",
                 mapper: WidgetEventMapper::WidgetDescriptionChanged {
-                    event_id: EVENT_ID.to_string(),
+                    event_id: DateTime::DT2023_01_01_00_00_00_00.id(),
                     payload: WidgetDescriptionChangedPayload::V1 {
                         widget_description: WIDGET_DESCRIPTION.to_string(),
                     },
@@ -642,7 +653,7 @@ mod tests {
                     assert_eq!(
                         json,
                         serde_json::json!({
-                            "event_id": EVENT_ID,
+                            "event_id": DateTime::DT2023_01_01_00_00_00_00.id(),
                             "event_name": "WidgetDescriptionChanged",
                             "payload": serde_json::json!({
                                 "version": "V1",

--- a/internal/adapter/src/repository.rs
+++ b/internal/adapter/src/repository.rs
@@ -169,7 +169,7 @@ mod tests {
     use kernel::error::{AggregateError, ApplyCommandError, LoadEventError};
     use kernel::processor::CommandProcessor;
     use kernel::Id;
-    use lib::Error;
+    use lib::{DateTime, Error};
     use testcontainers::clients::Cli;
     use testcontainers_modules::mysql::Mysql;
 
@@ -187,46 +187,6 @@ mod tests {
 
     const WIDGET_NAME: &str = "部品名";
     const WIDGET_DESCRIPTION: &str = "部品の説明";
-
-    #[allow(dead_code)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    enum DateTime {
-        /// 2023-01-01T00:00:00Z
-        DT2023_01_01_00_00_00_00,
-        /// 2023-01-01T00:00:01Z
-        DT2023_01_01_00_00_00_01,
-        /// 2023-01-01T00:00:02Z
-        DT2023_01_01_00_00_00_02,
-        /// 2023-01-01T00:01:00Z
-        DT2023_01_01_00_00_01_00,
-        /// 2023-01-01T01:00:00Z
-        DT2023_01_01_00_01_00_00,
-        /// 2023-01-01T01:00:00Z
-        DT2023_01_01_01_00_00_00,
-        /// 2023-01-02T00:00:00Z
-        DT2023_01_02_00_00_00_00,
-        /// 2023-02-01T00:00:00Z
-        DT2023_02_01_00_00_00_00,
-        /// 2024-01-01T00:00:00Z
-        DT2024_01_01_00_00_00_00,
-    }
-
-    impl DateTime {
-        fn id(self) -> String {
-            match self {
-                DateTime::DT2023_01_01_00_00_00_00 => "01GNNA1J00PQ9J874NBWERBM3Z",
-                DateTime::DT2023_01_01_00_00_00_01 => "01GNNA1J015CFH0CA590B4K9K6",
-                DateTime::DT2023_01_01_00_00_00_02 => "01GNNA1J02N9H1YCMRA2R9Q562",
-                DateTime::DT2023_01_01_00_00_01_00 => "01GNNA1JZ86A6F1G8HV7NYHDCN",
-                DateTime::DT2023_01_01_00_01_00_00 => "01GNNA3CK0B63HH8HBYQVRJ5Y8",
-                DateTime::DT2023_01_01_01_00_00_00 => "01GNNDFDM0WV3PR6RM8TEA7MZ5",
-                DateTime::DT2023_01_02_00_00_00_00 => "01GNQWE9003DQHKPAAHCDCVTJZ",
-                DateTime::DT2023_02_01_00_00_00_00 => "01GR57SPM0XBGEG4A13ZBW02G2",
-                DateTime::DT2024_01_01_00_00_00_00 => "01HK153X00D14NM09FKYEJ7MPY",
-            }
-            .to_string()
-        }
-    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum Fixture {

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kernel = { version = "0.1.0", path = "../kernel" }
+kernel = { path = "../kernel" }
 lib = { version = "0.1.0", path = "../lib" }
 thiserror = "1.0.56"
+
+[dev-dependencies]
+tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -8,9 +8,13 @@ edition = "2021"
 [dependencies]
 kernel = { path = "../kernel" }
 lib = { version = "0.1.0", path = "../lib" }
+mockall = { version = "0.12.1", optional = true }
 thiserror = "1.0.56"
 
 [dev-dependencies]
 kernel = { path = "../kernel", features = ["test", "mockall"] }
 lib = { path = "../lib", features = ["test"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+
+[features]
+mockall = ["dep:mockall"]

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -11,4 +11,5 @@ lib = { version = "0.1.0", path = "../lib" }
 thiserror = "1.0.56"
 
 [dev-dependencies]
+kernel = { path = "../kernel", features = ["test", "mockall"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/internal/app/Cargo.toml
+++ b/internal/app/Cargo.toml
@@ -12,4 +12,5 @@ thiserror = "1.0.56"
 
 [dev-dependencies]
 kernel = { path = "../kernel", features = ["test", "mockall"] }
+lib = { path = "../lib", features = ["test"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -166,51 +166,12 @@ mod tests {
     use kernel::error::{AggregateError, ApplyCommandError};
     use kernel::event::WidgetEvent;
     use kernel::processor::{CommandProcessor, MockCommandProcessor};
+    use lib::DateTime;
 
     use crate::{WidgetService, WidgetServiceError, WidgetServiceImpl, MAX_RETRY_COUNT};
 
     const WIDGET_NAME: &str = "部品名";
     const WIDGET_DESCRIPTION: &str = "部品の説明";
-
-    #[allow(dead_code)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    enum DateTime {
-        /// 2023-01-01T00:00:00Z
-        DT2023_01_01_00_00_00_00,
-        /// 2023-01-01T00:00:01Z
-        DT2023_01_01_00_00_00_01,
-        /// 2023-01-01T00:00:02Z
-        DT2023_01_01_00_00_00_02,
-        /// 2023-01-01T00:01:00Z
-        DT2023_01_01_00_00_01_00,
-        /// 2023-01-01T01:00:00Z
-        DT2023_01_01_00_01_00_00,
-        /// 2023-01-01T01:00:00Z
-        DT2023_01_01_01_00_00_00,
-        /// 2023-01-02T00:00:00Z
-        DT2023_01_02_00_00_00_00,
-        /// 2023-02-01T00:00:00Z
-        DT2023_02_01_00_00_00_00,
-        /// 2024-01-01T00:00:00Z
-        DT2024_01_01_00_00_00_00,
-    }
-
-    impl DateTime {
-        fn id(self) -> String {
-            match self {
-                DateTime::DT2023_01_01_00_00_00_00 => "01GNNA1J00PQ9J874NBWERBM3Z",
-                DateTime::DT2023_01_01_00_00_00_01 => "01GNNA1J015CFH0CA590B4K9K6",
-                DateTime::DT2023_01_01_00_00_00_02 => "01GNNA1J02N9H1YCMRA2R9Q562",
-                DateTime::DT2023_01_01_00_00_01_00 => "01GNNA1JZ86A6F1G8HV7NYHDCN",
-                DateTime::DT2023_01_01_00_01_00_00 => "01GNNA3CK0B63HH8HBYQVRJ5Y8",
-                DateTime::DT2023_01_01_01_00_00_00 => "01GNNDFDM0WV3PR6RM8TEA7MZ5",
-                DateTime::DT2023_01_02_00_00_00_00 => "01GNQWE9003DQHKPAAHCDCVTJZ",
-                DateTime::DT2023_02_01_00_00_00_00 => "01GR57SPM0XBGEG4A13ZBW02G2",
-                DateTime::DT2024_01_01_00_00_00_00 => "01HK153X00D14NM09FKYEJ7MPY",
-            }
-            .to_string()
-        }
-    }
 
     /// ApplyCommandError から WidgetServiceError に変換するテスト
     #[test]

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -48,6 +48,7 @@ impl From<AggregateError> for WidgetServiceError {
 }
 
 /// 部品 (Widget) のユースケース処理のインターフェイス
+#[cfg_attr(feature = "mockall", mockall::automock)]
 pub trait WidgetService {
     /// 部品を新しく作成する
     fn create_widget(

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -7,6 +7,8 @@ use kernel::processor::CommandProcessor;
 use lib::Error;
 use thiserror::Error;
 
+const MAX_RETRY_COUNT: u32 = 3;
+
 #[derive(Error, Debug)]
 pub enum WidgetServiceError {
     /// Aggregate が存在しないときのエラー
@@ -100,7 +102,6 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         widget_id: String,
         widget_name: String,
     ) -> Result<(), WidgetServiceError> {
-        const MAX_RETRY_COUNT: u32 = 3;
         let mut retry_count = 0;
         loop {
             let aggregate = self
@@ -129,7 +130,6 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
         widget_id: String,
         widget_description: String,
     ) -> Result<(), WidgetServiceError> {
-        const MAX_RETRY_COUNT: u32 = 3;
         let mut retry_count = 0;
         loop {
             if retry_count > MAX_RETRY_COUNT {
@@ -159,14 +159,55 @@ impl<C: CommandProcessor + Send + Sync + 'static> WidgetService for WidgetServic
 
 #[cfg(test)]
 mod tests {
+    use kernel::aggregate::WidgetAggregate;
     use kernel::error::AggregateError;
     use kernel::event::WidgetEvent;
     use kernel::processor::{CommandProcessor, MockCommandProcessor};
 
-    use crate::{WidgetService, WidgetServiceError, WidgetServiceImpl};
+    use crate::{WidgetService, WidgetServiceError, WidgetServiceImpl, MAX_RETRY_COUNT};
 
     const WIDGET_NAME: &str = "部品名";
     const WIDGET_DESCRIPTION: &str = "部品の説明";
+
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    enum DateTime {
+        /// 2023-01-01T00:00:00Z
+        DT2023_01_01_00_00_00_00,
+        /// 2023-01-01T00:00:01Z
+        DT2023_01_01_00_00_00_01,
+        /// 2023-01-01T00:00:02Z
+        DT2023_01_01_00_00_00_02,
+        /// 2023-01-01T00:01:00Z
+        DT2023_01_01_00_00_01_00,
+        /// 2023-01-01T01:00:00Z
+        DT2023_01_01_00_01_00_00,
+        /// 2023-01-01T01:00:00Z
+        DT2023_01_01_01_00_00_00,
+        /// 2023-01-02T00:00:00Z
+        DT2023_01_02_00_00_00_00,
+        /// 2023-02-01T00:00:00Z
+        DT2023_02_01_00_00_00_00,
+        /// 2024-01-01T00:00:00Z
+        DT2024_01_01_00_00_00_00,
+    }
+
+    impl DateTime {
+        fn id(self) -> String {
+            match self {
+                DateTime::DT2023_01_01_00_00_00_00 => "01GNNA1J00PQ9J874NBWERBM3Z",
+                DateTime::DT2023_01_01_00_00_00_01 => "01GNNA1J015CFH0CA590B4K9K6",
+                DateTime::DT2023_01_01_00_00_00_02 => "01GNNA1J02N9H1YCMRA2R9Q562",
+                DateTime::DT2023_01_01_00_00_01_00 => "01GNNA1JZ86A6F1G8HV7NYHDCN",
+                DateTime::DT2023_01_01_00_01_00_00 => "01GNNA3CK0B63HH8HBYQVRJ5Y8",
+                DateTime::DT2023_01_01_01_00_00_00 => "01GNNDFDM0WV3PR6RM8TEA7MZ5",
+                DateTime::DT2023_01_02_00_00_00_00 => "01GNQWE9003DQHKPAAHCDCVTJZ",
+                DateTime::DT2023_02_01_00_00_00_00 => "01GR57SPM0XBGEG4A13ZBW02G2",
+                DateTime::DT2024_01_01_00_00_00_00 => "01HK153X00D14NM09FKYEJ7MPY",
+            }
+            .to_string()
+        }
+    }
 
     /// 部品を作成するテスト
     #[tokio::test]
@@ -247,6 +288,133 @@ mod tests {
             let service = WidgetServiceImpl::new(test.command);
             let result = service
                 .create_widget(test.widget_name, test.widget_description)
+                .await;
+            (test.assert)(test.name, result);
+        }
+    }
+
+    /// 部品名を変更するテスト
+    #[tokio::test]
+    async fn test_change_widget_name() {
+        struct TestCase<T: CommandProcessor> {
+            name: &'static str,
+            widget_id: String,
+            widget_name: String,
+            command: T,
+            assert: fn(name: &str, result: Result<(), WidgetServiceError>),
+        }
+        let tests = vec![
+            TestCase {
+                name: "部品名の形式が正しく永続化時にエラーがない場合は、処理に成功する",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id(),
+                widget_name: "部品名v2".to_string(),
+                command: {
+                    let mut command = MockCommandProcessor::new();
+                    command.expect_get_widget_aggregate().returning(|_| {
+                        Box::pin(async {
+                            Ok(WidgetAggregate::new(
+                                DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
+                            )
+                            .set_name(WIDGET_NAME.to_string())
+                            .set_description(WIDGET_DESCRIPTION.to_string())
+                            .set_version(1))
+                        })
+                    });
+                    command
+                        .expect_update_widget_aggregate()
+                        .withf(|x| {
+                            matches!(
+                                x.events().first().unwrap(),
+                                WidgetEvent::WidgetNameChanged {
+                                    widget_name,
+                                    ..
+                                } if widget_name == "部品名v2"
+                            )
+                        })
+                        .times(1)
+                        .returning(|_| Box::pin(async { Ok(()) }));
+                    command
+                },
+                assert: |name, result| {
+                    assert!(result.is_ok(), "{name}");
+                },
+            },
+            TestCase {
+                name: "部品名の形式が不正な場合、WidgetServiceError::InvalidValue が返る",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
+                widget_name: String::new(),
+                command: {
+                    let mut command = MockCommandProcessor::new();
+                    command
+                        .expect_get_widget_aggregate()
+                        .returning(|_| Box::pin(async { Ok(WidgetAggregate::default()) }));
+                    command
+                        .expect_update_widget_aggregate()
+                        .returning(|_| Box::pin(async { Ok(()) }));
+                    command
+                },
+                assert: |name, result| {
+                    assert!(
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::InvalidValue)),
+                        "{name}"
+                    );
+                },
+            },
+            TestCase {
+                name: "永続化時に既に集約が更新されている場合、一定数再試行する",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
+                widget_name: WIDGET_NAME.to_string(),
+                command: {
+                    let mut command = MockCommandProcessor::new();
+                    command.expect_get_widget_aggregate().returning(|_| {
+                        Box::pin(async {
+                            Ok(WidgetAggregate::new(
+                                DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
+                            )
+                            .set_name(WIDGET_NAME.to_string())
+                            .set_description(WIDGET_DESCRIPTION.to_string())
+                            .set_version(1))
+                        })
+                    });
+                    command
+                        .expect_update_widget_aggregate()
+                        .times((MAX_RETRY_COUNT + 1) as usize) // NOTE: 最初の1回 + 再試行回数
+                        .returning(|_| Box::pin(async { Err(AggregateError::Conflict) }));
+                    command
+                },
+                assert: |name, result| {
+                    assert!(
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::AggregateConfilict)),
+                        "{name}"
+                    );
+                },
+            },
+            TestCase {
+                name: "永続化時に不明なエラーが発生した場合は、WidgetServiceError::Unknow が返る",
+                widget_id: DateTime::DT2023_01_01_00_00_00_00.id().parse().unwrap(),
+                widget_name: WIDGET_NAME.to_string(),
+                command: {
+                    let mut command = MockCommandProcessor::new();
+                    command
+                        .expect_get_widget_aggregate()
+                        .returning(|_| Box::pin(async { Ok(WidgetAggregate::default()) }));
+                    command.expect_update_widget_aggregate().returning(|_| {
+                        Box::pin(async { Err(AggregateError::Unknow("unknown".into())) })
+                    });
+                    command
+                },
+                assert: |name, result| {
+                    assert!(
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknow(_))),
+                        "{name}"
+                    );
+                },
+            },
+        ];
+        for test in tests {
+            let service = WidgetServiceImpl::new(test.command);
+            let result = service
+                .change_widget_name(test.widget_id, test.widget_name)
                 .await;
             (test.assert)(test.name, result);
         }

--- a/internal/app/src/lib.rs
+++ b/internal/app/src/lib.rs
@@ -21,7 +21,7 @@ pub enum WidgetServiceError {
     #[error("Invalid value")]
     InvalidValue,
     #[error("error")]
-    Unknow(#[from] Error),
+    Unknown(#[from] Error),
 }
 
 impl From<ApplyCommandError> for WidgetServiceError {
@@ -31,7 +31,7 @@ impl From<ApplyCommandError> for WidgetServiceError {
                 WidgetServiceError::InvalidValue
             }
             ApplyCommandError::VersionOverflow | ApplyCommandError::AggregationAlreadyCreated => {
-                WidgetServiceError::Unknow(value.into())
+                WidgetServiceError::Unknown(value.into())
             }
         }
     }
@@ -42,7 +42,7 @@ impl From<AggregateError> for WidgetServiceError {
         match value {
             AggregateError::Conflict => Self::AggregateConfilict,
             AggregateError::NotFound => Self::AggregateNotFound,
-            AggregateError::Unknow(e) => Self::Unknow(e),
+            AggregateError::Unknow(e) => Self::Unknown(e),
         }
     }
 }
@@ -192,11 +192,11 @@ mod tests {
             },
             TestCase {
                 error: ApplyCommandError::VersionOverflow,
-                assert: |error| assert!(matches!(error, WidgetServiceError::Unknow(_))),
+                assert: |error| assert!(matches!(error, WidgetServiceError::Unknown(_))),
             },
             TestCase {
                 error: ApplyCommandError::AggregationAlreadyCreated,
-                assert: |error| assert!(matches!(error, WidgetServiceError::Unknow(_))),
+                assert: |error| assert!(matches!(error, WidgetServiceError::Unknown(_))),
             },
         ];
         for test in tests {
@@ -222,7 +222,7 @@ mod tests {
             },
             TestCase {
                 error: AggregateError::Unknow("".into()),
-                assert: |error| assert!(matches!(error, WidgetServiceError::Unknow(_))),
+                assert: |error| assert!(matches!(error, WidgetServiceError::Unknown(_))),
             },
         ];
         for test in tests {
@@ -299,7 +299,7 @@ mod tests {
                 },
                 assert: |name, result| {
                     assert!(
-                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknow(_))),
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknown(_))),
                         "{name}"
                     );
                 },
@@ -426,7 +426,7 @@ mod tests {
                 },
                 assert: |name, result| {
                     assert!(
-                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknow(_))),
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknown(_))),
                         "{name}"
                     );
                 },
@@ -553,7 +553,7 @@ mod tests {
                 },
                 assert: |name, result| {
                     assert!(
-                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknow(_))),
+                        result.is_err_and(|e| matches!(e, WidgetServiceError::Unknown(_))),
                         "{name}"
                     );
                 },

--- a/internal/driver/Cargo.toml
+++ b/internal/driver/Cargo.toml
@@ -17,5 +17,6 @@ tower-http = { version = "0.5.1", features = ["timeout"] }
 [dev-dependencies]
 app = { path = "../app", features = ["mockall"] }
 lib = { path = "../lib", features = ["test"] }
+mockall = "0.12.1"
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"

--- a/internal/driver/Cargo.toml
+++ b/internal/driver/Cargo.toml
@@ -16,5 +16,6 @@ tower-http = { version = "0.5.1", features = ["timeout"] }
 
 [dev-dependencies]
 app = { path = "../app", features = ["mockall"] }
+lib = { path = "../lib", features = ["test"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"

--- a/internal/driver/Cargo.toml
+++ b/internal/driver/Cargo.toml
@@ -13,3 +13,8 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 tokio = { version = "1.36.0", default-features = false, features = ["signal"] }
 tower-http = { version = "0.5.1", features = ["timeout"] }
+
+[dev-dependencies]
+app = { path = "../app", features = ["mockall"] }
+tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tower = "0.4.13"

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -137,3 +137,31 @@ async fn shutdown_signal() {
     }
     println!("signal received, starting graceful shutdown");
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use app::MockWidgetService;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use lib::Error;
+    use tower::ServiceExt;
+
+    use crate::Server;
+
+    const ADDR: &str = "127.0.0.1:8080";
+
+    /// HealthCheck エンドポイントのテスト
+    #[tokio::test]
+    async fn test_healthcheck() -> Result<(), Error> {
+        let service = MockWidgetService::new();
+        let server = Server::new(ADDR, Arc::new(service));
+        let response = server
+            .router
+            .oneshot(Request::builder().uri("/healthz").body(Body::empty())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
+}

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -420,4 +420,119 @@ mod tests {
         }
         Ok(())
     }
+
+    /// 部品の説明を変更するエンドポイントのテスト
+    #[tokio::test]
+    async fn test_change_widget_description() -> Result<(), Error> {
+        struct TestCase<'a, T: WidgetService> {
+            name: &'a str,
+            service: T,
+            request: Request<Body>,
+            assert: AsyncAssertFn<'a>,
+        }
+        let tests = vec![
+            TestCase {
+                name: "リクエストボディの JSON の形式が正しい場合、202 が返る",
+                service: {
+                    let mut service = MockWidgetService::new();
+                    service
+                        .expect_change_widget_description()
+                        .withf(|id, description| {
+                            id == &DateTime::DT2023_01_01_00_00_00_00.id() && description == WIDGET_DESCRIPTION
+                        })
+                        .returning(|_, _| Box::pin(async { Ok(()) }));
+                    service
+                },
+                request: Request::builder()
+                    .method(Method::POST)
+                    .uri(format!(
+                        "/widgets/{}/description",
+                        DateTime::DT2023_01_01_00_00_00_00.id()
+                    ))
+                    .header(CONTENT_TYPE, CONTENT_TYPE_APPLICATION_JSON)
+                    .body(Body::from(
+                        serde_json::json!({
+                            "widget_description": WIDGET_DESCRIPTION,
+                        })
+                        .to_string(),
+                    ))?,
+                assert: (move |name, response| {
+                    Box::new(async move {
+                        assert_eq!(response.status(), StatusCode::ACCEPTED, "{name}");
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Service から InvalidValue のエラーが返ってきた場合、400 が返る",
+                service: {
+                    let mut service = MockWidgetService::new();
+                    service.expect_change_widget_description().returning(|_, _| {
+                        Box::pin(async { Err(WidgetServiceError::InvalidValue) })
+                    });
+                    service
+                },
+                request: Request::builder()
+                    .method(Method::POST)
+                    .uri(format!(
+                        "/widgets/{}/description",
+                        DateTime::DT2023_01_01_00_00_00_00.id()
+                    ))
+                    .header(CONTENT_TYPE, CONTENT_TYPE_APPLICATION_JSON)
+                    .body(Body::from(
+                        serde_json::json!({"widget_description": ""}).to_string(),
+                    ))?,
+                assert: (move |name, response| {
+                    Box::new(async move {
+                        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{name}");
+                        Ok(())
+                    })
+                }),
+            },
+            TestCase {
+                name: "Service から Unknown のエラーが返ってきた場合、500 が返る",
+                service: {
+                    let mut service = MockWidgetService::new();
+                    service.expect_change_widget_description().returning(|_, _| {
+                        Box::pin(async { Err(WidgetServiceError::Unknown("unknown".into())) })
+                    });
+                    service
+                },
+                request: Request::builder()
+                    .method(Method::POST)
+                    .uri(format!(
+                        "/widgets/{}/description",
+                        DateTime::DT2023_01_01_00_00_00_00.id()
+                    ))
+                    .header(CONTENT_TYPE, CONTENT_TYPE_APPLICATION_JSON)
+                    .body(Body::from(
+                        serde_json::json!({
+                            "widget_description": WIDGET_DESCRIPTION,
+                        })
+                        .to_string(),
+                    ))?,
+                assert: (move |name, response| {
+                    Box::new(async move {
+                        assert_eq!(
+                            response.status(),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "{name}"
+                        );
+                        assert_eq!(
+                            body::to_bytes(response.into_body(), usize::MAX).await?,
+                            "unknown",
+                            "{name}"
+                        );
+                        Ok(())
+                    })
+                }),
+            },
+        ];
+        for test in tests {
+            let server = Server::new(ADDR, Arc::new(test.service));
+            let response = server.router.oneshot(test.request).await?;
+            Pin::from((test.assert)(test.name, response)).await?;
+        }
+        Ok(())
+    }
 }

--- a/internal/driver/src/lib.rs
+++ b/internal/driver/src/lib.rs
@@ -149,6 +149,7 @@ mod tests {
     use axum::http::header::CONTENT_TYPE;
     use axum::http::{Method, Request, Response, StatusCode};
     use lib::{DateTime, Error};
+    use mockall::predicate;
     use tower::ServiceExt;
 
     use crate::Server;
@@ -192,9 +193,10 @@ mod tests {
                     let mut service = MockWidgetService::new();
                     service
                         .expect_create_widget()
-                        .withf(|name, description| {
-                            name == WIDGET_NAME && description == WIDGET_DESCRIPTION
-                        })
+                        .with(
+                            predicate::eq(WIDGET_NAME.to_string()),
+                            predicate::eq(WIDGET_DESCRIPTION.to_string()),
+                        )
                         .returning(|_, _| {
                             Box::pin(async { Ok(DateTime::DT2023_01_01_00_00_00_00.id()) })
                         });
@@ -322,9 +324,10 @@ mod tests {
                     let mut service = MockWidgetService::new();
                     service
                         .expect_change_widget_name()
-                        .withf(|id, name| {
-                            id == &DateTime::DT2023_01_01_00_00_00_00.id() && name == WIDGET_NAME
-                        })
+                        .with(
+                            predicate::eq(DateTime::DT2023_01_01_00_00_00_00.id()),
+                            predicate::eq(WIDGET_NAME.to_string()),
+                        )
                         .returning(|_, _| Box::pin(async { Ok(()) }));
                     service
                 },
@@ -437,9 +440,10 @@ mod tests {
                     let mut service = MockWidgetService::new();
                     service
                         .expect_change_widget_description()
-                        .withf(|id, description| {
-                            id == &DateTime::DT2023_01_01_00_00_00_00.id() && description == WIDGET_DESCRIPTION
-                        })
+                        .with(
+                            predicate::eq(DateTime::DT2023_01_01_00_00_00_00.id()),
+                            predicate::eq(WIDGET_DESCRIPTION.to_string()),
+                        )
                         .returning(|_, _| Box::pin(async { Ok(()) }));
                     service
                 },
@@ -467,9 +471,11 @@ mod tests {
                 name: "Service から InvalidValue のエラーが返ってきた場合、400 が返る",
                 service: {
                     let mut service = MockWidgetService::new();
-                    service.expect_change_widget_description().returning(|_, _| {
-                        Box::pin(async { Err(WidgetServiceError::InvalidValue) })
-                    });
+                    service
+                        .expect_change_widget_description()
+                        .returning(|_, _| {
+                            Box::pin(async { Err(WidgetServiceError::InvalidValue) })
+                        });
                     service
                 },
                 request: Request::builder()
@@ -493,9 +499,11 @@ mod tests {
                 name: "Service から Unknown のエラーが返ってきた場合、500 が返る",
                 service: {
                     let mut service = MockWidgetService::new();
-                    service.expect_change_widget_description().returning(|_, _| {
-                        Box::pin(async { Err(WidgetServiceError::Unknown("unknown".into())) })
-                    });
+                    service
+                        .expect_change_widget_description()
+                        .returning(|_, _| {
+                            Box::pin(async { Err(WidgetServiceError::Unknown("unknown".into())) })
+                        });
                     service
                 },
                 request: Request::builder()

--- a/internal/kernel/Cargo.toml
+++ b/internal/kernel/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 lib = { version = "0.1.0", path = "../lib" }
+mockall = "0.12.1"
 thiserror = "1.0.56"
 ulid = "1.1.2"

--- a/internal/kernel/Cargo.toml
+++ b/internal/kernel/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [dependencies]
 lib = { version = "0.1.0", path = "../lib" }
-mockall = "0.12.1"
+mockall = { version = "0.12.1", optional = true }
 thiserror = "1.0.56"
 ulid = "1.1.2"
+
+[features]
+test = []
+mockall = ["dep:mockall"]

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -88,16 +88,19 @@ impl WidgetAggregate {
         Ok(self)
     }
 
+    #[cfg(feature = "test")]
     pub fn set_name(mut self, name: String) -> Self {
         self.name = name;
         self
     }
 
+    #[cfg(feature = "test")]
     pub fn set_description(mut self, description: String) -> Self {
         self.description = description;
         self
     }
 
+    #[cfg(feature = "test")]
     pub fn set_version(mut self, version: u64) -> Self {
         self.version = version;
         self

--- a/internal/kernel/src/aggregate.rs
+++ b/internal/kernel/src/aggregate.rs
@@ -87,6 +87,21 @@ impl WidgetAggregate {
         }
         Ok(self)
     }
+
+    pub fn set_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn set_description(mut self, description: String) -> Self {
+        self.description = description;
+        self
+    }
+
+    pub fn set_version(mut self, version: u64) -> Self {
+        self.version = version;
+        self
+    }
 }
 
 /// 集約 (Aggregate) に対するコマンドの処理を成功して保存可能になった状態

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -3,6 +3,7 @@ use crate::error::AggregateError;
 use crate::Id;
 
 /// 集約を永続化する処理のインターフェイス
+#[mockall::automock]
 pub trait CommandProcessor {
     /// 部品の集約を新しく作成する
     fn create_widget_aggregate(

--- a/internal/kernel/src/processor.rs
+++ b/internal/kernel/src/processor.rs
@@ -3,7 +3,7 @@ use crate::error::AggregateError;
 use crate::Id;
 
 /// 集約を永続化する処理のインターフェイス
-#[mockall::automock]
+#[cfg_attr(feature = "mockall", mockall::automock)]
 pub trait CommandProcessor {
     /// 部品の集約を新しく作成する
     fn create_widget_aggregate(

--- a/internal/lib/Cargo.toml
+++ b/internal/lib/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[features]
+test = []

--- a/internal/lib/src/lib.rs
+++ b/internal/lib/src/lib.rs
@@ -9,3 +9,44 @@ pub fn database_url() -> String {
         option_env!("MYSQL_DATABASE").unwrap_or("widget")
     )
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg(feature = "test")]
+pub enum DateTime {
+    /// 2023-01-01T00:00:00Z
+    DT2023_01_01_00_00_00_00,
+    /// 2023-01-01T00:00:01Z
+    DT2023_01_01_00_00_00_01,
+    /// 2023-01-01T00:00:02Z
+    DT2023_01_01_00_00_00_02,
+    /// 2023-01-01T00:01:00Z
+    DT2023_01_01_00_00_01_00,
+    /// 2023-01-01T01:00:00Z
+    DT2023_01_01_00_01_00_00,
+    /// 2023-01-01T01:00:00Z
+    DT2023_01_01_01_00_00_00,
+    /// 2023-01-02T00:00:00Z
+    DT2023_01_02_00_00_00_00,
+    /// 2023-02-01T00:00:00Z
+    DT2023_02_01_00_00_00_00,
+    /// 2024-01-01T00:00:00Z
+    DT2024_01_01_00_00_00_00,
+}
+
+#[cfg(feature = "test")]
+impl DateTime {
+    pub fn id(self) -> String {
+        match self {
+            DateTime::DT2023_01_01_00_00_00_00 => "01GNNA1J00PQ9J874NBWERBM3Z",
+            DateTime::DT2023_01_01_00_00_00_01 => "01GNNA1J015CFH0CA590B4K9K6",
+            DateTime::DT2023_01_01_00_00_00_02 => "01GNNA1J02N9H1YCMRA2R9Q562",
+            DateTime::DT2023_01_01_00_00_01_00 => "01GNNA1JZ86A6F1G8HV7NYHDCN",
+            DateTime::DT2023_01_01_00_01_00_00 => "01GNNA3CK0B63HH8HBYQVRJ5Y8",
+            DateTime::DT2023_01_01_01_00_00_00 => "01GNNDFDM0WV3PR6RM8TEA7MZ5",
+            DateTime::DT2023_01_02_00_00_00_00 => "01GNQWE9003DQHKPAAHCDCVTJZ",
+            DateTime::DT2023_02_01_00_00_00_00 => "01GR57SPM0XBGEG4A13ZBW02G2",
+            DateTime::DT2024_01_01_00_00_00_00 => "01HK153X00D14NM09FKYEJ7MPY",
+        }
+        .to_string()
+    }
+}

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -1,8 +1,8 @@
-use lib::{database_url, Result};
+use lib::{database_url, Error};
 use sqlx::{Connection, MySqlConnection};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Error> {
     let mut pool = MySqlConnection::connect(&database_url()).await?;
     sqlx::query(include_str!(
         "../../migrations/20240210132634_create_aggregate.sql"


### PR DESCRIPTION
## Overview

[mockall](https://docs.rs/mockall/latest/mockall/) で kernel/app のモックを作成して、テストに利用する

## Features

- CommandProcesser のモックを利用した WidgetService のテストを追加する
- WidgetService のモックを利用した Server のテストを追加する

## Fixes

- 部品名・説明の変更時の一定回数以上再試行しない
- migrate バイナリの依存関係を修正
